### PR TITLE
Fix npm install failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is The Jitsi Handbook. Your one-stop-shop for Jitsi documentation. It's pow
 
 ## Install dependencies
 
-If you use windows, please execute
+If you use **Windows**, you need install ```gifsicle```:
 
 ```js 
 npm install -g gifsicle
@@ -14,14 +14,14 @@ alternative command
 cnpm install gifsicle
 ```
 
-If you use Debian/Ubuntu, please execute
+If you use **Debian/Ubuntu**, you need install ```gifsicle```:
 
 ```shell
 apt-get update
 apt-get install dh-autoreconf
 ```
 
-If you use MacOS, please execute it first
+If you use **MacOS**, you need install ```gifsicle```:
 
 ```shell
 brew install automake

--- a/README.md
+++ b/README.md
@@ -2,24 +2,19 @@
 
 This is The Jitsi Handbook. Your one-stop-shop for Jitsi documentation. It's powered by [Docusaurus](https://docusaurus.io/).
 
-## Building the site
-
-The site is built automatically with every push thanks to a [GH Actions](https://github.com/jitsi/handbook/blob/master/.github/workflows/gh-pages.yml).
-
-If you want to build it locally, follow these simple steps:
+## Install dependencies
 
 If you use windows, please execute
 
 ```js 
 npm install -g gifsicle
 ```
-perhaps
-
+alternative command
 ```js
 cnpm install gifsicle
 ```
 
-If you use Linux, please execute
+If you use Debian/Ubuntu, please execute
 
 ```shell
 apt-get update
@@ -31,6 +26,12 @@ If you use MacOS, please execute it first
 ```shell
 brew install automake
 ```
+
+## Building the site
+
+The site is built automatically with every push thanks to a [GH Actions](https://github.com/jitsi/handbook/blob/master/.github/workflows/gh-pages.yml).
+
+If you want to build it locally, follow these simple steps:
 
 ```js
 cd website

--- a/README.md
+++ b/README.md
@@ -12,11 +12,24 @@ If you use windows, please execute
 
 ```js 
 npm install -g gifsicle
-``
+```
 perhaps
 
 ```js
 cnpm install gifsicle
+```
+
+If you use Linux, please execute
+
+```shell
+apt-get update
+apt-get install dh-autoreconf
+```
+
+If you use MacOS, please execute it first
+
+```shell
+brew install automake
 ```
 
 ```js

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ The site is built automatically with every push thanks to a [GH Actions](https:/
 
 If you want to build it locally, follow these simple steps:
 
+If you use windows, please execute
+
+```js 
+npm install -g gifsicle
+``
+perhaps
+
+```js
+cnpm install gifsicle
+```
+
 ```js
 cd website
 npm install

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ alternative command
 cnpm install gifsicle
 ```
 
-If you use **Debian/Ubuntu**, you need install ```gifsicle```:
+If you use **Debian/Ubuntu**, you need install ```dh-autoreconf```:
 
 ```shell
 apt-get update
 apt-get install dh-autoreconf
 ```
 
-If you use **MacOS**, you need install ```gifsicle```:
+If you use **MacOS**, you need install ```automake```:
 
 ```shell
 brew install automake


### PR DESCRIPTION
##  This error occurs with  ``` npm install ``` 
```
gifsicle@4.0.1 postinstall /Users/cgland/Documents/jitsi/handbook/website/node_modules/gifsicle
> node lib/install.js

  ⚠ connect ECONNREFUSED 0.0.0.0:443
  ⚠ gifsicle pre-build test failed
  ℹ compiling from source
  ✖ Error: Command failed: /bin/sh -c autoreconf -ivf
/bin/sh: autoreconf: command not found


    at /Users/cgland/Documents/jitsi/handbook/website/node_modules/execa/index.js:231:11
    at processTicksAndRejections (internal/process/task_queues.js:85:5)
npm WARN website No repository field.
npm WARN website No license field.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! gifsicle@4.0.1 postinstall: `node lib/install.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the gifsicle@4.0.1 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/cgland/.npm/_logs/2020-07-11T03_04_31_633Z-debug.log
```

I saw a lot of the same mistakes on the Internet. Please see [issue](https://github.com/imagemin/imagemin-gifsicle/issues/37)

I solved this problem locally and submitted PR, please review to avoid more people having the same problem