### PR TITLE
fix manual insatll Jitsi Videobridge

### DIFF
--- a/docs/devops-guide/manual.md
+++ b/docs/devops-guide/manual.md
@@ -164,18 +164,34 @@ ln -s ../sites-available/jitsi.example.com jitsi.example.com
 ```
 
 ## Install Jitsi Videobridge
-Visit https://download.jitsi.org/jitsi-videobridge/linux to determine the current build number, download and unzip it:
+
+You can download binary packages for Debian/Ubuntu:
+* [stable](https://download.jitsi.org/stable/) ([instructions](https://jitsi.org/downloads/ubuntu-debian-installations-instructions/))
+* [testing](https://download.jitsi.org/testing/) ([instructions](https://jitsi.org/downloads/ubuntu-debian-installations-instructions-for-testing/))
+* [nightly](https://download.jitsi.org/unstable/) ([instructions](https://jitsi.org/downloads/ubuntu-debian-installations-instructions-nightly/))
+
+Or you can clone the Git repo and run the JVB from source using maven.
+
+Install JDK and Maven if missing:
+
 ```sh
-wget https://download.jitsi.org/jitsi-videobridge/linux/jitsi-videobridge-linux-{arch-buildnum}.zip
-unzip jitsi-videobridge-linux-{arch-buildnum}.zip
+apt-get install openjdk-8-jdk maven
 ```
 
-Install JRE if missing:
-```
-apt-get install openjdk-8-jre
+Clone source from Github repo:
+
+```sh
+cd /srv
+git clone https://github.com/jitsi/jitsi-videobridge.git
 ```
 
-_NOTE: When installing on older Debian releases keep in mind that you need JRE >= 1.7._
+Build the package:
+
+```sh
+export JVB_HOME="The path to your JVB clone."
+cd jitsi/jitsi-videobridge
+mvn install
+```
 
 Create `~/.sip-communicator/sip-communicator.properties` in the home folder of the user that will be starting Jitsi Videobridge:
 ```sh
@@ -190,11 +206,13 @@ EOF
 
 Start the videobridge with:
 ```sh
+unzip target/jitsi-videobridge-2.1-SNAPSHOT-archive.zip
+cd jitsi-videobridge-2.1-SNAPSHOT/
 ./jvb.sh --host=localhost --domain=jitsi.example.com --port=5347 --secret=YOURSECRET1 &
 ```
 Or autostart it by adding the line in `/etc/rc.local`:
 ```sh
-/bin/bash /root/jitsi-videobridge-linux-{arch-buildnum}/jvb.sh --host=localhost --domain=jitsi.example.com --port=5347 --secret=YOURSECRET1 </dev/null >> /var/log/jvb.log 2>&1
+/bin/bash /srv/jitsi-videobridge/jitsi-videobridge-2.1-SNAPSHOT/jvb.sh --host=localhost --domain=jitsi.example.com --port=5347 --secret=YOURSECRET1 </dev/null >> /var/log/jvb.log 2>&1
 ```
 
 ## Install Jitsi Conference Focus (jicofo)


### PR DESCRIPTION
When I use self hosting Guide - [manual installation,](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-manual) when I install ***jitsi videobridge***:
```wget https://download.jitsi.org/jitsi-videobridge/linux/jitsi-videobridge-linux-x64-1120.zip```
Resolving download.jitsi.org 1 (download.jitsi.org 1)… 52.88.166.130, 35.164.147.194
Connecting to download.jitsi.org 1 (download.jitsi.org 1)|52.88.166.130|:443… connected.
HTTP request sent, awaiting response… 404 Not Found
2020-06-25 08:45:23 ERROR 404: Not Found.

open ```https://download.jitsi.org/jitsi-videobridge/linux```  There was 404

I put forward corresponding questions in the forum [link](https://community.jitsi.org/t/dowload-jitsi-videobridge-404/67825)

But after a long time, the document did not fix this error, so I submitted this PR, hoping that others can install it normally



