### PR TITLE
Fix/dropbox 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is The Jitsi Handbook. Your one-stop-shop for Jitsi documentation. It's pow
 
 ## Install dependencies
 
-If you use windows, please execute
+If you use **Windows**, you need install ```gifsicle```:
 
 ```js 
 npm install -g gifsicle
@@ -14,14 +14,14 @@ alternative command
 cnpm install gifsicle
 ```
 
-If you use Debian/Ubuntu, please execute
+If you use **Debian/Ubuntu**, you need install ```gifsicle```:
 
 ```shell
 apt-get update
 apt-get install dh-autoreconf
 ```
 
-If you use MacOS, please execute it first
+If you use **MacOS**, you need install ```gifsicle```:
 
 ```shell
 brew install automake

--- a/README.md
+++ b/README.md
@@ -2,24 +2,19 @@
 
 This is The Jitsi Handbook. Your one-stop-shop for Jitsi documentation. It's powered by [Docusaurus](https://docusaurus.io/).
 
-## Building the site
-
-The site is built automatically with every push thanks to a [GH Actions](https://github.com/jitsi/handbook/blob/master/.github/workflows/gh-pages.yml).
-
-If you want to build it locally, follow these simple steps:
+## Install dependencies
 
 If you use windows, please execute
 
 ```js 
 npm install -g gifsicle
 ```
-perhaps
-
+alternative command
 ```js
 cnpm install gifsicle
 ```
 
-If you use Linux, please execute
+If you use Debian/Ubuntu, please execute
 
 ```shell
 apt-get update
@@ -31,6 +26,12 @@ If you use MacOS, please execute it first
 ```shell
 brew install automake
 ```
+
+## Building the site
+
+The site is built automatically with every push thanks to a [GH Actions](https://github.com/jitsi/handbook/blob/master/.github/workflows/gh-pages.yml).
+
+If you want to build it locally, follow these simple steps:
 
 ```js
 cd website

--- a/README.md
+++ b/README.md
@@ -12,11 +12,24 @@ If you use windows, please execute
 
 ```js 
 npm install -g gifsicle
-``
+```
 perhaps
 
 ```js
 cnpm install gifsicle
+```
+
+If you use Linux, please execute
+
+```shell
+apt-get update
+apt-get install dh-autoreconf
+```
+
+If you use MacOS, please execute it first
+
+```shell
+brew install automake
 ```
 
 ```js

--- a/README.md
+++ b/README.md
@@ -4,24 +4,24 @@ This is The Jitsi Handbook. Your one-stop-shop for Jitsi documentation. It's pow
 
 ## Install dependencies
 
-If you use **Windows**, you need install ```gifsicle```:
+If you use **Windows**, you need to install ```gifsicle```:
 
 ```js 
 npm install -g gifsicle
 ```
-alternative command
+alternative command:
 ```js
 cnpm install gifsicle
 ```
 
-If you use **Debian/Ubuntu**, you need install ```dh-autoreconf```:
+If you use **Debian/Ubuntu**, you need to install ```dh-autoreconf```:
 
 ```shell
 apt-get update
 apt-get install dh-autoreconf
 ```
 
-If you use **MacOS**, you need install ```automake```:
+If you use **MacOS**, you need to install ```automake```:
 
 ```shell
 brew install automake

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ The site is built automatically with every push thanks to a [GH Actions](https:/
 
 If you want to build it locally, follow these simple steps:
 
+If you use windows, please execute
+
+```js 
+npm install -g gifsicle
+``
+perhaps
+
+```js
+cnpm install gifsicle
+```
+
 ```js
 cd website
 npm install

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ alternative command
 cnpm install gifsicle
 ```
 
-If you use **Debian/Ubuntu**, you need install ```gifsicle```:
+If you use **Debian/Ubuntu**, you need install ```dh-autoreconf```:
 
 ```shell
 apt-get update
 apt-get install dh-autoreconf
 ```
 
-If you use **MacOS**, you need install ```gifsicle```:
+If you use **MacOS**, you need install ```automake```:
 
 ```shell
 brew install automake

--- a/docs/dev-guide/web-integrations.md
+++ b/docs/dev-guide/web-integrations.md
@@ -35,11 +35,12 @@ sidebar_label: Integrations
     1. 'Dropbox API - For apps that need to access files in Dropbox.' 
     1. 'App folder– Access to a single folder created specifically for your app.'
     1. Fill in the name of your app
-1. You need only, the newly created App key, goes in config.js in 
+1. You need only, the newly created App key, goes in ```/etc/jitsi/meet/yourdeployment.com-config.js``` in 
     ```
         dropbox: {
-            appKey: '__dropbox_app_key__'
+            appKey: '__dropbox_app_key__',
+            redirectURI: 'https://yourdeployment.com/static/oauth.html'
         }
     ```
-1. Add your Redirect URIs in the form `https://yourdeployment.com//static/oauth.html`
+1. Add your Dropbox Redirect URIs in the Dropbox form `https://yourdeployment.com/static/oauth.html`
 1. Fill in Branding


### PR DESCRIPTION
1. to make clear config.js For installation using [Devops guide QuickStart](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-quickstart).
2.Do you think it is necessary to highlight the redirect URI in the document?
3.`https://yourdeployment.com//static/oauth.html` Revised as `https://yourdeployment.com//static/oauth.html`
4.Do you think this subfolder is misleading? I think it's better to delete it because it doesn't apply to users who use [Devops guide QuickStart](https://github.com/jitsi/jitsi-meet/blob/master/config.js#L186).
