### PR TITLE
Updating quick start (FQDN)

### DIFF
--- a/docs/devops-guide/quickstart.md
+++ b/docs/devops-guide/quickstart.md
@@ -59,11 +59,16 @@ If the machine used to host the Jitsi Meet instance has a FQDN (for example `mee
 
 Then add the same FQDN in the `/etc/hosts` file, associating it with the loopback address:
 
-    127.0.0.1 localhost meet.example.org
+    127.0.0.1 localhost
+    x.x.x.x meet.example.org meet
+Note: `x.x.x.x` is your server's public IP address.
 
 Finally on the same machine test that you can ping the FQDN with:
 
 `ping "$(hostname)"`
+
+If all worked as expected, you should see:
+`meet.example.com`
 
 ### Add the Jitsi package repository
 

--- a/docs/devops-guide/quickstart.md
+++ b/docs/devops-guide/quickstart.md
@@ -55,7 +55,7 @@ If your computer/server or router has a dynamic IP address (the IP address chang
 
 If the machine used to host the Jitsi Meet instance has a FQDN (for example `meet.example.org`) already set up in DNS, you can set it with the following command:
 
-`sudo hostnamectl set-hostname meet.example.org`
+`sudo hostnamectl set-hostname meet`
 
 Then add the same FQDN in the `/etc/hosts` file, associating it with the loopback address:
 


### PR DESCRIPTION
Updating FQDN section example to add an example of configuring the /etc/hosts file for FQDN.