### PR TITLE
Include instructions for workaround for JVB issue #1336

### DIFF
--- a/docs/devops-guide/quickstart.md
+++ b/docs/devops-guide/quickstart.md
@@ -17,6 +17,8 @@ _Note_: Many of the installation steps require `root` or `sudo` access.
 You will need the following packages:
 * `gnupg2`
 * `sudo` # only needed if you use sudo
+* `openjdk-8-jdk`
+* `nginx`
 
 Make sure your system is up-to-date and required packages are installed:
 
@@ -143,8 +145,10 @@ If you are already running Nginx on port 443 on the same machine, turnserver con
 
 ```sh
 # jitsi-meet installation
-sudo apt install jitsi-meet
+sudo apt install --no-install-recommends jitsi-meet
 ```
+
+You need the `--no-install-recommends` flags because the current version of jitsi-meet recommends a version of the JDK that does not work; make sure you have `openjdk-8-jdk` installed beforehand.
 
 **SSL/TLS certificate generation:**
 You will be asked about SSL/TLS certificate generation. 

--- a/docs/devops-guide/quickstart.md
+++ b/docs/devops-guide/quickstart.md
@@ -18,7 +18,7 @@ You will need the following packages:
 * `gnupg2`
 * `sudo` # only needed if you use sudo
 * `openjdk-8-jdk`
-* `nginx`
+* `nginx` (or Apache)
 
 Make sure your system is up-to-date and required packages are installed:
 
@@ -138,7 +138,7 @@ During installation of Jitsi Meet you can choose between different options:
 
 ### Install Jitsi Meet
 
-_Note_: The installer will check if [Nginx](https://nginx.org/) or [Apache](https://httpd.apache.org/) are present (in that order) and configure a virtual host within the web server it finds to serve Jitsi Meet. If none of the above is found it then defaults to Nginx.
+_Note_: The installer will check if [Nginx](https://nginx.org/) or [Apache](https://httpd.apache.org/) are present (in that order) and configure a virtual host within the web server it finds to serve Jitsi Meet. If you don't have a webserver, make sure to install one beforehand, e.g. run `apt install nginx`.
 
 If you are already running Nginx on port 443 on the same machine, turnserver configuration will be skipped as it will conflict with your current port 443.
 
@@ -148,7 +148,7 @@ If you are already running Nginx on port 443 on the same machine, turnserver con
 sudo apt install --no-install-recommends jitsi-meet
 ```
 
-You need the `--no-install-recommends` flags because the current version of jitsi-meet recommends a version of the JDK that does not work; make sure you have `openjdk-8-jdk` installed beforehand.
+You need the `--no-install-recommends` flags because the current version of jitsi-meet recommends a version of the JDK that does not work. You need to have OpenJDK installed instead, so make sure you have `openjdk-8-jdk` installed beforehand.
 
 **SSL/TLS certificate generation:**
 You will be asked about SSL/TLS certificate generation. 


### PR DESCRIPTION
See issue https://github.com/jitsi/jitsi-videobridge/issues/1366 and community forum post https://community.jitsi.org/t/jicofo-logs-showing-error-sslexception-received-fatal-alert-protocol-version/71938/4.

If someone who is in charge of the actual Ubuntu package distribution could instead update the install recommends, that would be great, but I don't know how to do that.