### PR TITLE
Update secure-domain.md

### DIFF
--- a/docs/devops-guide/secure-domain.md
+++ b/docs/devops-guide/secure-domain.md
@@ -96,7 +96,12 @@ Finally, run `prosodyctl` to create a user in Prosody:
 ```
 sudo prosodyctl register <username> jitsi-meet.example.com <password>
 ```
-
+and then restart prosody, jicofo and jitsi-videobridge2
+```
+systemctl restart prosody
+systemctl restart jicofo
+systemctl restart jitsi-videobridge2
+```
 ## Optional: Jigasi configuration
 
 ### Enable Authentication


### PR DESCRIPTION
without restarting all 3 servers, changes do not work as intended. Otherwise host and guest all are requested to enter username and password to join a meeting.