### PR TITLE
Clarify use of STUN and DOCKER_HOST_ADDRESS

### DIFF
--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -454,8 +454,7 @@ the ``DOCKER_HOST_ADDRESS`` should be set. This way, the Videobridge will advert
 of the host running Docker instead of the internal IP address that Docker assigned it, thus making [ICE]
 succeed. If your users are coming in over the Internet (and not over LAN), this will likely be your public IP address. If this is not set up correctly, calls will crash when more than two users join a meeting.
 
-The public IP address is discovered via [STUN]. STUN servers can be specified with the ``JVB_STUN_SERVERS``
-option.
+Alternatively, the public IP address can be discovered using [STUN]. STUN servers are specified with the ``JVB_STUN_SERVERS`` option.
 
 ## Build Instructions
 


### PR DESCRIPTION
The way the document currently reads, it appears that a user needs to specify a `DOCKER_HOST_ADDRESS` to let the software know about its public IP address, AND that public IP address will be discovered, which doesn't make sense.

I'm not sure how this exactly works, but my suggested verbiage is how I would like it to work. If my proposal isn't correct, please correct it to make the document more usable.