### PR TITLE
Document how to join a Jitsi Meeting

### DIFF
--- a/docs/user-guide/join-a-jitsi-meeting.md
+++ b/docs/user-guide/join-a-jitsi-meeting.md
@@ -4,11 +4,17 @@ title: Join a Jitsi Meeting
 sidebar_label: Join a Jitsi Meeting
 ---
 
+# Join by using a Jitsi link
 
-1. When visiting a Jitsi Meeting link, your browser may first ask you to grant microphone and/or camera access.
-   Please refert to the browser's documentation for details (e.g.
+People invite each other to Jitsi meetings mostly by sending a link.
+
+1. If you have received such an invite link from a trusted source,
+   copy it into your browser and press <kbd>Enter</kbd>/<kbd>Return</kbd>.
+2. Your browser may first ask you to grant microphone and/or camera access.
+   If you trust the person who invited you, confirm this access request.
+   Please refer to the browser's documentation for details (e.g.
    [Firefox](https://support.mozilla.org/kb/how-manage-your-camera-and-microphone-permissions#w_using-prompts-to-allow-or-block-camera-and-microphone-permissions-for-a-site), 
    [Chrome](https://support.google.com/chrome/answer/2693767)).
-1. Enter a name. This will be visible to other participants in the Jitsi Meeting room.
-1. (optional) Adjust the camera and/or microphone settings via the `v` dropdown menu items.
-1. Click `Join meeting`.
+3. Enter a name, which will be visible to other participants in the Jitsi Meeting room.
+4. (optional) Adjust the camera and/or microphone settings via the `v` dropdown menu items.
+5. Click `Join meeting`.

--- a/docs/user-guide/join-a-jitsi-meeting.md
+++ b/docs/user-guide/join-a-jitsi-meeting.md
@@ -11,4 +11,4 @@ sidebar_label: Join a Jitsi Meeting
    [Chrome](https://support.google.com/chrome/answer/2693767)).
 1. Enter a name. This will be visible to other participants in the Jitsi Meeting room.
 1. (optional) Adjust the camera and/or microphone settings via the `v` dropdown menu items.
-1. Click `Join meeting`,
+1. Click `Join meeting`.

--- a/docs/user-guide/join-a-jitsi-meeting.md
+++ b/docs/user-guide/join-a-jitsi-meeting.md
@@ -4,6 +4,11 @@ title: Join a Jitsi Meeting
 sidebar_label: Join a Jitsi Meeting
 ---
 
-Welcome to the user guide!
 
-Check back soon!
+1. When visiting a Jitsi Meeting link, your browser may first ask you to grant microphone and/or camera access.
+   Please refert to the browser's documentation for details (e.g.
+   [Firefox](https://support.mozilla.org/kb/how-manage-your-camera-and-microphone-permissions#w_using-prompts-to-allow-or-block-camera-and-microphone-permissions-for-a-site), 
+   [Chrome](https://support.google.com/chrome/answer/2693767)).
+1. Enter a name. This will be visible to other participants in the Jitsi Meeting room.
+1. (optional) Adjust the camera and/or microphone settings via the `v` dropdown menu items.
+1. Click `Join meeting`,


### PR DESCRIPTION
Shorter alternative to https://github.com/jitsi/handbook/pull/48. This here is written for users who receive a meeting link created by someone else, thus skips the `Open meet… URL` step from [PR #48](https://github.com/jitsi/handbook/pull/48/files#diff-fa01af1c63e267d0d799404522b1223afeed1e5fb50b760161f59aafb0e43007).

By linking to the browser's own docu about the permissions popups, we can also ensure that no docu here needs to be kept up to date with browser UI updates.