### PR TITLE
Add clarification on anonymous authentication.

### DIFF
--- a/docs/devops-guide/secure-domain.md
+++ b/docs/devops-guide/secure-domain.md
@@ -26,7 +26,7 @@ Replace `jitsi-meet.example.com` with your hostname.
 
 ### Enable anonymous login for guests
 
-Add this block to enable the anonymous login method for guests:
+Add this block **after the previous VirtualHost** to enable the anonymous login method for guests:
 
 ```
 VirtualHost "guest.jitsi-meet.example.com"
@@ -34,7 +34,7 @@ VirtualHost "guest.jitsi-meet.example.com"
     c2s_require_encryption = false
 ```
 
-_Note that `guest.jitsi-meet.example.com` is internal to Jitsi, and you do not need to (and should not) create a DNS record for it, or generate an SSL/TLS certificate, or do any web server configuration._
+_Note that `guest.jitsi-meet.example.com` is internal to Jitsi, and you do not need to (and should not) create a DNS record for it, or generate an SSL/TLS certificate, or do any web server configuration. While it is internal, you should still replace `jitsi-meet.example.com` with your hostname._
 
 :::note
 Make sure to enable the desired modules for the guest virtual host like `turncredentials` (if you use STUN/TURN together with secure domain) and/or `conference_duration` etc., by adding the `modules_enabled` option.


### PR DESCRIPTION
I've been setting up my own instance, and I found [this external documentation](https://jitsi-club.gitlab.io/jitsi-self-hosting/en/01-deployment-howto/01-authentication/) helped me to properly set it up, after having tried multiple times to get anonymous authentication to work. In fact, the problem was that I had consistently put the `guest.domain` *before* the `domain` VirtualHost.

Making this change to the documentation will help people to avoid this pitfall. I look forward to being part of the process of improving documentation for this fantastic conference tool.