### PR TITLE
Improve first step of "Building the sources"

### DIFF
--- a/docs/dev-guide/web.md
+++ b/docs/dev-guide/web.md
@@ -14,11 +14,9 @@ Node.js >= 12 and npm >= 6 are required.
 :::
 
 On Debian/Ubuntu systems, the required packages can be installed with:
-```
-download linux-binaries(x64) from  https://nodejs.org/en/download/
-install the downlaoded file node*.tar.xz
-follow the document https://community.jitsi.org/t/how-to-how-to-build-jitsi-meet-from-source-a-developers-guide/75422
-```
+- Download "Linux Binaries (x64)" from https://nodejs.org/en/download/
+- Install Node.js following these instructions: https://github.com/nodejs/help/wiki/Installation
+- Follow the document https://community.jitsi.org/t/how-to-how-to-build-jitsi-meet-from-source-a-developers-guide/75422
 
 To build the Jitsi Meet application, just type
 ```


### PR DESCRIPTION
- fix formatting
- replace "install the downloaded file" with a link to the Node.js installation instructions