### PR TITLE
Fixed misspelled API command

### DIFF
--- a/docs/dev-guide/iframe.md
+++ b/docs/dev-guide/iframe.md
@@ -751,7 +751,7 @@ api.executeCommand('stopRecording',
 Opens the chat window and sets the participant with the given participant ID as the messages recipient.
 
 ```javascript
-api.executeCommand('intiatePrivateChat',
+api.executeCommand('initiatePrivateChat',
     participantID: string
 );
 ```


### PR DESCRIPTION
As already mentioned [here](https://github.com/jitsi/jitsi-meet/issues/9098), this PR fixes a typo in the Jitsi IFrame API