### PR TITLE
added statement re payload encoding for reservation API

### DIFF
--- a/docs/devops-guide/reservation.md
+++ b/docs/devops-guide/reservation.md
@@ -81,6 +81,8 @@ included:
  contain user's identity. It that case it will not be possible to create new
  conference room without authenticating.
 
+The payload sent to the endpoint will be encoded as `application/x-www-form-urlencoded`.
+
 Then reservation system is expected to respond with one of the following
 responses:
 


### PR DESCRIPTION
Clearly state in docs that reservation plugin will call API endpoint with form encoded data (even though it expects JSON in return).

Being explicit about this in docs could clear up confusion. (Just had a long thread on community forum when the issue eventually turned out to be user assuming JSON payload instead of x-www-form-urlencoded.