### PR TITLE
Provide web configuration section for docker-compose

### DIFF
--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -224,7 +224,7 @@ The JSON with the Dial-In numbers should look like this:
 {"message":"Dial-In numbers:","numbers":{"DE": ["+49-721-0000-0000"]},"numbersEnabled":true}
 ```
 
-### JItsi BRoadcasting Infrastructure (Jibri) configuration
+### Jitsi Broadcasting Infrastructure (Jibri) configuration
 
 Before running Jibri, you need to set up an ALSA loopback device on the host. This **will not**
 work on a non-Linux host.

--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -340,6 +340,26 @@ For using multiple Jibri instances, you have to select different loopback interf
 
 </details>
 
+### Jitsi-Meet web configuration
+
+:::tip This section partly contains duplicate settings
+
+There are settings within your ``docker-compose.yml`` like ``START_AUDIO_MUTED``
+that will be overwritten if you follow the below guide.
+
+:::
+
+Jitsi-Meet uses two configuration files for changing default settings within
+the web interface: ``config.js`` and ``interface_config.js``. The files are
+located within the ``CONFIG`` directory configured within your environment file.
+
+These files are re-created on every container restart. 
+If you'd like to provide your own settings, create your own config files:
+``custom-config.js`` and ``custom-interface_config.js``.
+
+It's enough to provide your relevant settings only, the docker scripts will 
+append your custom files to the default ones!
+
 ### Authentication
 
 Authentication can be controlled with the environment variables below. If guest


### PR DESCRIPTION
This PR adds a section that hints on how to adjust config.js and interface_config.js as one can no longer directly edit said files. This came up in https://github.com/jitsi/docker-jitsi-meet/issues/1058 because the docker-compose started to behave differently from the way it did before. 