### PR TITLE
Bumps minimum debian version

### DIFF
--- a/docs/devops-guide/quickstart.md
+++ b/docs/devops-guide/quickstart.md
@@ -6,7 +6,7 @@ sidebar_label: Debian/Ubuntu server
 
 Follow these steps for a quick Jitsi-Meet installation on a Debian-based GNU/Linux system.
 The following distributions are supported out-of-the-box:
-- Debian 9 (Stretch) or newer
+- Debian 10 (Buster) or newer
 - Ubuntu 18.04 (Bionic Beaver) or newer
 
 _Note_: Many of the installation steps require `root` or `sudo` access. 


### PR DESCRIPTION
Debian 9 misses ruby-hocon dependency.