### PR TITLE
Add building of lib-jitsi-meet .min.js files

### DIFF
--- a/docs/dev-guide/web.md
+++ b/docs/dev-guide/web.md
@@ -23,11 +23,7 @@ Then go ahead:
 git clone https://github.com/jitsi/jitsi-meet
 cd ./jitsi-meet
 
-# Build lib-jitsi-meet .min.js files, which are required by the jitsi-meet build process
-cd node_modules/lib-jitsi-meet
 npm install
-npm run postinstall
-cd ../..
 
 # To build the Jitsi Meet application, just type
 make

--- a/docs/dev-guide/web.md
+++ b/docs/dev-guide/web.md
@@ -23,6 +23,12 @@ Then go ahead:
 git clone https://github.com/jitsi/jitsi-meet
 cd ./jitsi-meet
 
+# Build lib-jitsi-meet .min.js files, which are required by the jitsi-meet build process
+cd node_modules/lib-jitsi-meet
+npm install
+npm run postinstall
+cd ../..
+
 # To build the Jitsi Meet application, just type
 make
 ```


### PR DESCRIPTION
Suggestion to add this step to the documentation -- or perhaps as part of the Makefile instead?