### PR TITLE
Update secure-domain.md

### DIFF
--- a/docs/devops-guide/secure-domain.md
+++ b/docs/devops-guide/secure-domain.md
@@ -75,13 +75,13 @@ jicofo {
  ...
 ```
 
-When using token based authentication, the type must use `EXT_JWT` as the scheme instead:
+When using token based authentication, the type must use `JWT` as the scheme instead:
 
 ```
 jicofo {
   authentication: {
     enabled: true
-    type: EXT_JWT
+    type: JWT
     login-url: jitsi-meet.example.com
  }
  ...

--- a/docs/devops-guide/secure-domain.md
+++ b/docs/devops-guide/secure-domain.md
@@ -63,17 +63,28 @@ authenticated domain.
 org.jitsi.jicofo.auth.URL=XMPP:jitsi-meet.example.com
 ```
 
-If you have installed Jicofo from the Debian package, this should go directly on a new line in
-the `/etc/jitsi/jicofo/sip-communicator.properties`:
+If you have installed Jicofo from the Debian package, this should go as a new 'authentication' section in `/etc/jitsi/jicofo/jicofo.conf`:
 
 ```
-org.jitsi.jicofo.auth.URL=XMPP:jitsi-meet.example.com
+jicofo {
+  authentication: {
+    enabled: true
+    type: XMPP
+    login-url: jitsi-meet.example.com
+ }
+ ...
 ```
 
-When using token based authentication, the URL must use `EXT_JWT` as the scheme instead:
+When using token based authentication, the type must use `EXT_JWT` as the scheme instead:
 
 ```
-org.jitsi.jicofo.auth.URL=EXT_JWT:jitsi-meet.example.com
+jicofo {
+  authentication: {
+    enabled: true
+    type: EXT_JWT
+    login-url: jitsi-meet.example.com
+ }
+ ...
 ```
 
 ## Create users in Prosody (internal auth)


### PR DESCRIPTION
The documentation does not work for Ubuntu 20.04. Specifically jicofo configuration change is not working. After normal installation there is no sip-communicator.properties in /etc/jitsi/jicofo folder. So changing the documentation to show how to edit jicofo.conf file.