### PR TITLE
Specify file location for jicofo.auth.URL

### DIFF
--- a/docs/devops-guide/secure-domain.md
+++ b/docs/devops-guide/secure-domain.md
@@ -57,7 +57,7 @@ var config = {
 
 When running Jicofo, specify your main domain in an additional configuration
 property. Jicofo will accept conference allocation requests only from the
-authenticated domain.
+authenticated domain. This should go in `/etc/jitsi/jicofo/sip-communicator.properties`.
 
 ```
 org.jitsi.jicofo.auth.URL=XMPP:jitsi-meet.example.com


### PR DESCRIPTION
The file location for placing the config parameter org.jitsi.jicofo.auth.URL isn't clear in the original document. Other Jitsi Community users (e.g. ygramoel) also had this issue.