### PR TITLE
Update Supported Distributions

### DIFF
--- a/docs/devops-guide/quickstart.md
+++ b/docs/devops-guide/quickstart.md
@@ -7,7 +7,7 @@ sidebar_label: Debian/Ubuntu server
 Follow these steps for a quick Jitsi-Meet installation on a Debian-based GNU/Linux system.
 The following distributions are supported out-of-the-box:
 - Debian 10 (Buster) or newer
-- Ubuntu 18.04 (Bionic Beaver) or newer
+- Ubuntu 20.04 (Focal Fossa) or newer (Ubuntu 18.04 can be used, but Prosody version must be updated to 0.11+ before installation)
 
 _Note_: Many of the installation steps require `root` or `sudo` access. 
 


### PR DESCRIPTION
Ubuntu 18.04 comes with Prosody 0.10 by default. Jitsi now requires Prosody 0.11+. Users should know they'll need to update Prosody (preferably) before installing Jitsi, if their OS is 18.04. Ubuntu 20.04 is supported out-of-the-box.