### PR TITLE
Updated Ios dependencies link

### DIFF
--- a/docs/dev-guide/ios-sdk.md
+++ b/docs/dev-guide/ios-sdk.md
@@ -68,7 +68,7 @@ you may want to set `UIViewControllerBasedStatusBarAppearance` to `NO` in your
 
 ### Building it yourself
 
-1. Install all required [dependencies](mobile.md).
+1. Install all required [dependencies](https://github.com/jitsi/jitsi-meet/blob/591ea0a44a98f35e4752be837302f8f1a7935ced/doc/mobile.md).
 
 2. Build it:
 

--- a/docs/dev-guide/ios-sdk.md
+++ b/docs/dev-guide/ios-sdk.md
@@ -68,7 +68,7 @@ you may want to set `UIViewControllerBasedStatusBarAppearance` to `NO` in your
 
 ### Building it yourself
 
-1. Install all required [dependencies](https://github.com/jitsi/jitsi-meet/blob/591ea0a44a98f35e4752be837302f8f1a7935ced/doc/mobile.md).
+1. Install all required [dependencies](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-mobile-jitsi-meet).
 
 2. Build it:
 


### PR DESCRIPTION
As illustrated by  this user in  the community forum - 

https://community.jitsi.org/t/handbook-link-to-ios-sdk-dependencies-points-to-the-wrong-place/112527

I updated the doc to point to the supposed right location for installing IOS dependencies.

