### PR TITLE
Document how to access server logs

### DIFF
--- a/docs/community/third-party-software.md
+++ b/docs/community/third-party-software.md
@@ -84,6 +84,6 @@ Docker: https://github.com/H2-invent/jitsi-admin/wiki/Install-jitsi-admin-in-doc
 
 ## Outlook Plugin 
 
-Plugin for Adding a "Schedule Jitsi Meeting" Button to a Meeting
+Plugin for Adding a "Schedule Jitsi Meeting" Button to Microsoft Outlook.
 
 GitHub: https://github.com/timetheoretical/jitsi-meet-outlook

--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -668,33 +668,37 @@ STUN servers can be specified with the ``JVB_STUN_SERVERS`` option.
 Due to a bug in the docker version currently in the Debian repos (20.10.5), [Docker does not listen on IPv6 ports](https://forums.docker.com/t/docker-doesnt-open-ipv6-ports/106201/2), so for that combination you will have to [manually obtain the latest version](https://docs.docker.com/engine/install/debian/).
 :::
 
-## Logging
+## Accessing server logs
 
-The default bahavior of `docker-jitsi-meet` is to log to `stdout`. The only exception to this is Jibri. 
+The default bahavior of `docker-jitsi-meet` is to log to `stdout`.
 
 While the logs are sent to `stdout`, they are not lost: unless configured to drop all logs, Docker keeps them available for future retrieval and processing.
 
-If you need to access the container's logs you have multiple options. The main ones are the following ones:
+If you need to access the container's logs you have multiple options. Here are the main ones:
 
 * run `docker-compose logs -t -f <service_name>` from command line, where `<service_name>` is one of `web`, `prosody`,`jvb`, `jicofo`. This command will output the logs for the selected service to stdout with timestamps.
 * use a standard [docker logging driver](https://docs.docker.com/config/containers/logging/configure/) to redirect the logs to the desired target (for instance `syslog` or `splunk`).
-* use an existing docker logging driver plugin or [write your own](https://docs.docker.com/engine/extend/plugins_logging/).
+* serach [docker hub](https://hub.docker.com/search?q=) for a third party [docker logging driver plugin](https://docs.docker.com/config/containers/logging/plugins/) 
+* or [write your own driver plugin](https://docs.docker.com/engine/extend/plugins_logging/) if you have a very specific need.
 
 For instance, if you want to have all logs related to a `<service_name>` written to `/var/log/jitsi/<service_name>` as `json` output, you could use [docker-file-log-driver](https://github.com/deep-compute/docker-file-log-driver) and configure it by adding the following block in your `docker-compose.yml` file, at the same level as the `image` block of the selected `<service_name>`:
 
 ```
+services:
+    <service_name>:
+        image: ...
+        ...
         logging:
             driver: file-log-driver
             options:
                 fpath: "/jitsi/<service_name>.log"
-
 ```
 
-If you want to only display the `message` part of the log in `json` format, simply execute the following command (for instance if `fpath` was set to `/jitsi/jvb.log`):
+If you want to only display the `message` part of the log in `json` format, simply execute the following command (for instance if `fpath` was set to `/jitsi/jvb.log`) which uses `jq` to extract the relevant part of the logs:
 
 
 ```
-sudo cat /var/log/jitsi/jvb.log |jq -r '.msg'| jq -r '.message'
+sudo cat /var/log/jitsi/jvb.log | jq -r '.msg' | jq -r '.message'
 ```
 
 ## Build Instructions

--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -668,6 +668,35 @@ STUN servers can be specified with the ``JVB_STUN_SERVERS`` option.
 Due to a bug in the docker version currently in the Debian repos (20.10.5), [Docker does not listen on IPv6 ports](https://forums.docker.com/t/docker-doesnt-open-ipv6-ports/106201/2), so for that combination you will have to [manually obtain the latest version](https://docs.docker.com/engine/install/debian/).
 :::
 
+## Logging
+
+The default bahavior of `docker-jitsi-meet` is to log to `stdout`. The only exception to this is Jibri. 
+
+While the logs are sent to `stdout`, they are not lost: unless configured to drop all logs, Docker keeps them available for future retrieval and processing.
+
+If you need to access the container's logs you have multiple options. The main ones are the following ones:
+
+* run `docker-compose logs -t -f <service_name>` from command line, where `<service_name>` is one of `web`, `prosody`,`jvb`, `jicofo`. This command will output the logs for the selected service to stdout with timestamps.
+* use a standard [docker logging driver](https://docs.docker.com/config/containers/logging/configure/) to redirect the logs to the desired target (for instance `syslog` or `splunk`).
+* use an existing docker logging driver plugin or [write your own](https://docs.docker.com/engine/extend/plugins_logging/).
+
+For instance, if you want to have all logs related to a `<service_name>` written to `/var/log/jitsi/<service_name>` as `json` output, you could use [docker-file-log-driver](https://github.com/deep-compute/docker-file-log-driver) and configure it by adding the following block in your `docker-compose.yml` file, at the same level as the `image` block of the selected `<service_name>`:
+
+```
+        logging:
+            driver: file-log-driver
+            options:
+                fpath: "/jitsi/<service_name>.log"
+
+```
+
+If you want to only display the `message` part of the log in `json` format, simply execute the following command (for instance if `fpath` was set to `/jitsi/jvb.log`):
+
+
+```
+sudo cat /var/log/jitsi/jvb.log |jq -r '.msg'| jq -r '.message'
+```
+
 ## Build Instructions
 
 Building your images allows you to edit the configuration files of each image individually, providing more customization for your deployment.


### PR DESCRIPTION
Following @saghul [suggestion](https://github.com/jitsi/docker-jitsi-meet/issues/1340#issuecomment-1172274178), adding a section to the handbook explaining how to access `docker-jitsi-meet` server logs without having to mount docker volumes.