### PR TITLE
Install lua5.2 to fix problem with jwt modules.

### DIFF
--- a/docs/devops-guide/quickstart.md
+++ b/docs/devops-guide/quickstart.md
@@ -97,6 +97,7 @@ This will add the Prosody repository so that an up to date Prosody is installed,
 ```bash
 echo deb http://packages.prosody.im/debian $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list
 wget https://prosody.im/files/prosody-debian-packages.key -O- | sudo apt-key add -
+apt install lua5.2
 ```
 
 ### Add the Jitsi package repository


### PR DESCRIPTION
When installing on machine without lua5.2 pre-installed the prosody coming from their repositories install lua5.3 by default.
The packages lua-basexx and cjson are supporting lua 5.1 and 5.2. 
For the time being we stick to 5.2 till those are fixed.