### PR TITLE
Add jitsi-meet/jaas-choice debconf var

### DIFF
--- a/docs/devops-guide/scalable.md
+++ b/docs/devops-guide/scalable.md
@@ -84,8 +84,12 @@ jitsi-meet-prosody	jitsi-videobridge/jvb-hostname	string	meet.example.com
 jitsi-meet-web-config	jitsi-meet/cert-choice	select	I want to use my own certificate
 jitsi-meet-web-config	jitsi-meet/cert-path-crt	string	/etc/ssl/meet.example.com.crt
 jitsi-meet-web-config	jitsi-meet/cert-path-key	string	/etc/ssl/meet.example.com.key
+jitsi-meet-web-config	jitsi-meet/jaas-choice	boolean	false
 EOF
 ```
+
+To enable integration with [Jitsi Meet Components](https://jaas.8x8.vc/#/components) for telephony support, set
+the `jitsi-meet/jaas-choice` option above to `true`.
 
 On the jitsi-meet server, install the following packages:
 


### PR DESCRIPTION
Add new debconf var to examples for scalable setup.

Related community post: https://community.jitsi.org/t/deps-on-lua-inspect-breaks-installation-on-ubuntu-18/117218/7?u=shawn