### PR TITLE
Fix JVB_ADVERTISE_IPS typo in docker docs

### DIFF
--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -678,7 +678,7 @@ Variable | Description | Default value
 
 ### Running behind NAT or on a LAN environment
 
-When running running in a LAN environment, or on the public Internet via NAT, the ``JVB_ADVERSITED_IPS`` env variable should be set.
+When running running in a LAN environment, or on the public Internet via NAT, the ``JVB_ADVERTISE_IPS`` env variable should be set.
 This variable allows to control which IP addresses the JVB will advertise for WebRTC media traffic.
 
 :::note


### PR DESCRIPTION
Fixes https://github.com/jitsi/handbook/issues/378

As per https://github.com/jitsi/docker-jitsi-meet/commit/c53de728cedf54edcbb94e104b3a45fd029f8b9d