### PR TITLE
set the correct permissions for prosody

### DIFF
--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -31,6 +31,7 @@ follow these steps:
    * For linux: 
    ```bash
    mkdir -p ~/.jitsi-meet-cfg/{web,transcripts,prosody/config,prosody/prosody-plugins-custom,jicofo,jvb,jigasi,jibri}
+   chown -R 101:102 ~/.jitsi-meet-cfg/{prosody}
    ```
    * For Windows: 
    ```bash


### PR DESCRIPTION
Following https://github.com/jitsi/docker-jitsi-meet/issues/1448: Add instruction to set the correct permission for the prosody config files. Otherwise changing the prosody users will fail.