### PR TITLE
add jitsi-keycloak-adapter to third-party software list

### DIFF
--- a/docs/community/third-party-software.md
+++ b/docs/community/third-party-software.md
@@ -86,6 +86,12 @@ https://shawnchin.github.io/jitsi-url-generator/
 
 Github: https://github.com/shawnchin/jitsi-url-generator
 
+## KeyCloak adapter
+
+Allow Jitsi to use Keycloak as an identity and OIDC provider.
+
+https://github.com/nordeck/jitsi-keycloak-adapter
+
 ## KeyCloak integration
 
 Integration of KeyCloak for authentication.


### PR DESCRIPTION
`jitsi-keycloak-adapter` is added to the third-party software list

https://github.com/nordeck/jitsi-keycloak-adapter