### PR TITLE
Added nonParticipantMessageReceived event

### DIFF
--- a/docs/dev-guide/iframe-events.md
+++ b/docs/dev-guide/iframe-events.md
@@ -146,6 +146,19 @@ The listener receives an object with the following structure:
 }
 ```
 
+### nonParticipantMessageReceived
+
+Provides event notifications about a messages sent by a non-participant, e.g. a custom prosody message.
+
+The listener receives an object with the following structure:
+
+```javascript
+{
+        id: string, // the id of the message, may be null
+        message: string // the message received
+}
+```
+
 ### faceLandmarkDetected
 
 Provides event notifications when a face landmark is detected
@@ -720,7 +733,7 @@ The listener receives an object with the following structure:
 Provides notifications about detecting suspended events in the host computer.
 
 ### peerConnectionFailure
-    
+
 Notify the external application that a PeerConnection lost connectivity. This event is fired only if
 a PC `failed` but connectivity to the rtcstats server is still maintained signaling that there is a
 problem establishing a link between the app and the JVB server or the remote peer in case of P2P.
@@ -729,12 +742,12 @@ Will only fire if rtcstats is enabled.
 ```javascript
 {
     // Type of PC, Peer2Peer or JVB connection.
-    isP2P: boolean, 
+    isP2P: boolean,
 
     // Was this connection previously connected. If it was it could mean
     // that connectivity was disrupted, if not it most likely means that the app could not reach
     // the JVB server, or the other peer in case of P2P.
-    wasConnected: boolean 
+    wasConnected: boolean
 }
 ```
 


### PR DESCRIPTION
Added documentation for nonParticipantMessageReceived event to iFrame API.

This is for the Jitsi-Meet PR #13440