### PR TITLE
Replace sudo tee with sudo curl

### DIFF
--- a/docs/devops-guide/quickstart.md
+++ b/docs/devops-guide/quickstart.md
@@ -102,7 +102,7 @@ apt install lua5.2
 ```
 **Ubuntu 22.04**
 ```bash
-curl -sL https://prosody.im/files/prosody-debian-packages.key | sudo tee /etc/apt/keyrings/prosody-debian-packages.key
+sudo curl -sL https://prosody.im/files/prosody-debian-packages.key -o /etc/apt/keyrings/prosody-debian-packages.key
 echo "deb [signed-by=/etc/apt/keyrings/prosody-debian-packages.key] http://packages.prosody.im/debian $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/prosody-debian-packages.list
 apt install lua5.2
 ```


### PR DESCRIPTION
Replaced the tee with a sudo curl, as tee doesn't know what to do with the binary DSA key and makes your terminal a mess.