### PR TITLE
Fix Broken Links on React and Flutter SDK Dev Guide Pages

### DIFF
--- a/docs/dev-guide/android-sdk.md
+++ b/docs/dev-guide/android-sdk.md
@@ -13,7 +13,7 @@ Android 6.0 (API level 23) or higher is required.
 ## Sample applications using the SDK
 
 If you want to see how easy integrating the Jitsi Meet SDK into a native application is, take a look at the
-[sample applications repository](https://github.com/jitsi/jitsi-meet-sdk-samples).
+[sample applications repository](https://github.com/jitsi/jitsi-meet-sdk-samples#android).
 
 ## Build your own, or use a pre-build SDK artifacts/binaries
 

--- a/docs/dev-guide/flutter-sdk.md
+++ b/docs/dev-guide/flutter-sdk.md
@@ -8,7 +8,7 @@ The Jitsi Meet Flutter SDK provides the same user experience as the Jitsi Meet a
 ## Sample application using the Flutter
 
 If you want to see how easy integrating the Jitsi Meet Flutter SDK into a Flutter application is, take a look at the<br/>
-[sample applications repository](https://github.com/jitsi/jitsi-meet-sdk-samples/flutter).
+[sample applications repository](https://github.com/jitsi/jitsi-meet-sdk-samples#flutter).
 
 ## Installation
 

--- a/docs/dev-guide/ios-sdk.md
+++ b/docs/dev-guide/ios-sdk.md
@@ -13,7 +13,7 @@ iOS 12.4 or higher is required.
 ## Sample applications using the SDK
 
 If you want to see how easy integrating the Jitsi Meet SDK into a native application is, take a look at the
-[sample applications repository](https://github.com/jitsi/jitsi-meet-sdk-samples).
+[sample applications repository](https://github.com/jitsi/jitsi-meet-sdk-samples#ios).
 
 ## Usage
 

--- a/docs/dev-guide/react-native-sdk.md
+++ b/docs/dev-guide/react-native-sdk.md
@@ -9,7 +9,7 @@ in a customizable way which you can embed in your React Native apps.
 ## Sample application using the React Native SDK
 
 If you want to see how easy integrating the Jitsi React Native SDK into a React Native application is, take a look at the<br/>
-[sample applications repository](https://github.com/jitsi/jitsi-meet-sdk-samples/react-native).
+[sample applications repository](https://github.com/jitsi/jitsi-meet-sdk-samples#react-native).
 
 ## Usage
 


### PR DESCRIPTION
**Pull Request: Fix Broken Links on React and Flutter SDK Dev Guide Pages**

_Description:_

This PR addresses two broken links found on the following pages:
1. [React SDK Dev Guide](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-react-sdk)
2. [Flutter SDK Dev Guide](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-flutter-sdk)

Both pages were supposed to link to the [jitsi-meet-sdk-samples](https://github.com/jitsi/jitsi-meet-sdk-samples/) repository. I've updated the invalid links to correctly point to the intended repository.

Please review and merge if all looks good. Thank you!