### PR TITLE
Typo Correction on 'Modifying lib-jitsi-meet' Page

### DIFF
--- a/docs/dev-guide/ljm.md
+++ b/docs/dev-guide/ljm.md
@@ -5,7 +5,7 @@ title: Modifying lib-jitsi-meet
 
 # Modifying `lib-jitsi-meet`
 
-By default the library is referenced as a prebuilt artifact in a HitHub release. Packages are NOT published to npm. The default dependency path in package.json is:
+By default the library is referenced as a prebuilt artifact in a GitHub release. Packages are NOT published to npm. The default dependency path in package.json is:
 
 ```json
 "lib-jitsi-meet": "https://github.com/jitsi/lib-jitsi-meet/releases/download/v<version>+<commit-hash>/lib-jitsi-meet.tgz)",


### PR DESCRIPTION
**Pull Request: Typo Correction on 'Modifying lib-jitsi-meet' Page**

_Description:_

This PR addresses a small typo found on the ['Modifying lib-jitsi-meet'](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-ljm) page. The incorrect spelling "HitHub" has been corrected to "GitHub".

Please review and merge if everything seems in order. Thanks for the oversight!