### PR TITLE
Prosody metrics collection documentation for handbook

### DIFF
--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -689,8 +689,8 @@ Variable | Description | Default value
 `PROSODY_RESERVATION_ENABLED` | Enable Prosody's reservation REST API | false
 `PROSODY_RESERVATION_REST_BASE_URL` | Base URL of Prosody's reservation REST API |
 `PROSODY_AUTH_TYPE` | Select authentication type for Prosody (internal, jwt or ldap) | `AUTH_TYPE`
-`PROSODY_ENABLE_METRICS` | Enables the collection of metrics in Prosody | false
-`PROSODY_METRICS_ALLOWED_CIDR` | CIDR block permitted to access metrics from the internal Docker network | 172.16.0.0/12
+`PROSODY_ENABLE_METRICS` | Enables the http_openmetrics module which exposes Prometheus metrics at `/metrics` | false
+`PROSODY_METRICS_ALLOWED_CIDR` | CIDR block permitted to access metrics | 172.16.0.0/12
 
 #### Advanced Jicofo options
 

--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -689,6 +689,8 @@ Variable | Description | Default value
 `PROSODY_RESERVATION_ENABLED` | Enable Prosody's reservation REST API | false
 `PROSODY_RESERVATION_REST_BASE_URL` | Base URL of Prosody's reservation REST API |
 `PROSODY_AUTH_TYPE` | Select authentication type for Prosody (internal, jwt or ldap) | `AUTH_TYPE`
+`PROSODY_ENABLE_METRICS` | Enables the collection of metrics in Prosody | false
+`PROSODY_METRICS_ALLOWED_CIDR` | CIDR block permitted to access metrics from the internal Docker network | 172.16.0.0/12
 
 #### Advanced Jicofo options
 


### PR DESCRIPTION
### Updated Documentation for Metrics Variables

I have added descriptions for two metrics-related environment variables in the Jitsi Meet handbook:

1. **`PROSODY_METRICS_ALLOWED_CIDR`**: "CIDR block permitted to access metrics from the internal Docker network."
2. **`PROSODY_ENABLE_METRICS`**: "Enables the collection of metrics in Prosody."

These additions aim to provide clear explanations for users configuring metrics collection in Jitsi Meet.

Please review the changes and let me know if any adjustments are needed.

Thank you!