### PR TITLE
Fix the nginx proxy configuration and improve the reverse proxy documentation

### DIFF
--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -912,7 +912,7 @@ location / {
 
 #### Apache
 
-With Apache, `mod_proxy` and `mod_proxy_wstunnel` need to be enabled.
+With Apache, `mod_proxy`, `mod_proxy_http` and `mod_proxy_wstunnel` need to be enabled.
       
 The reverse proxy can be configured using the following config snippet:
 

--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -883,7 +883,7 @@ Due to the hop-by-hop nature of WebSockets the reverse proxy must properly termi
 
 The other HTTP requests must be handled by the web container.
 
-In the following configuration examples, `http://localhost:8000/` is the url of the web service's ingress.
+In the following configuration examples, `http://localhost:8000/` is the url of the web service's ingress (`8000` corresponds to `HTTP_PORT`).
 
 #### nginx
 


### PR DESCRIPTION
Consecutively to my previous pull request #533 I took some time to setup an nginx server and tried the proxy configuration.

This enabled me to fix multiple things:
- Proxy to the HTTP server instead of the HTTPS one
- Proxy all the paths to the web container and not only `/http-bind`
- Fix the target paths of the Web Socket proxies (`/xmpp-websocket` must target `/xmpp-websocket` and not `/`)
- Remove the Web Socket related configuration from the HTTP-only proxy (for `/`)

This configuration seems to work as expected.

I also reorganized the reverse proxy paragraph in order to share between Apache and nginx the explanation I added in my previous PR regarding the usage of HTTP instead of HTTPS and how to disable HTTPS.

I also added a required module for Apache (`proxy_http`).

Hope this will help!