### PR TITLE
Remove a useless sentense in the Apache proxy documentation for Docker

### DIFF
--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -928,8 +928,6 @@ The reverse proxy can be configured using the following config snippet:
 </IfModule>
 ```
 
-where `http://localhost:8000/` is the url of the web service's ingress.
-
 ### Disabling WebSocket connections
 
 :::note


### PR DESCRIPTION
Sorry, I forgot to remove this line in my previous PR. It is no longer required since I factorized this explanation for both nginx and Apache.