### PR TITLE
Update iframe-events.md

### DIFF
--- a/docs/dev-guide/iframe-events.md
+++ b/docs/dev-guide/iframe-events.md
@@ -323,10 +323,11 @@ The listener receives an object with the following structure:
 
 ```javascript
 {
-    from: string, // The id of the user that sent the message
+    from: string, // the id of the user that sent the message
     nick: string, // the nickname of the user that sent the message
     privateMessage: boolean, // whether this is a private or group message
     message: string // the text of the message
+    stamp: string // the message timestamp as string (ISO-8601)
 }
 ```
 


### PR DESCRIPTION
Added missing payload variable `stamp`. Additionally set the first `the` to lowercase to keep everything the same.

```
{
from: '22995f22', 
message: 'hello', 
nick: 'tester', 
privateMessage: false, 
stamp: '2024-11-21T07:33:38Z'
}
```