### PR TITLE
Removed info type

### DIFF
--- a/docs/dev-guide/iframe-commands.md
+++ b/docs/dev-guide/iframe-commands.md
@@ -672,7 +672,7 @@ api.executeCommand('showNotification', {
   title: String, // Title of the notification.
   description: String, // Content of the notification.
   uid: String, // Optional. Unique identifier for the notification.
-  type: String, // Optional. Can be 'info', 'normal', 'success', 'warning' or 'error'. Defaults to 'normal'.
+  type: String, // Optional. Can be 'normal', 'success', 'warning' or 'error'. Defaults to 'normal'.
   timeout: String // optional. Can be 'short', 'medium', 'long', or 'sticky'. Defaults to 'short'.
 });
 ```


### PR DESCRIPTION
There is no `info` type in `showNotification` command.

https://github.com/jitsi/jitsi-meet/blob/9846228210d99122710a4a2144aba03478df5775/react/features/notifications/constants.ts#L26