### PR TITLE
Fixed wrong link in iframe.md

### DIFF
--- a/docs/dev-guide/iframe.md
+++ b/docs/dev-guide/iframe.md
@@ -16,7 +16,7 @@ JaaS customers, please make sure you also read [this](https://developer.8x8.com/
 :::
 
 :::tip
-If you use React in your web application you might want to use our [React SDK](dev-guide-react-sdk) instead.
+If you use React in your web application you might want to use our [React SDK](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-react-sdk/) instead.
 :::
 
 ## Integration


### PR DESCRIPTION
https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe had a link to the react sdk documentation which was incorrect (https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe/dev-guide-react-sdk). I fixed the link (https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe/dev-guide-react-sdk).