### PR TITLE
Fix variable name in docker.md

### DIFF
--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -868,7 +868,7 @@ HTTPS can be disabled in the Docker Compose configuration (since HTTPS will prob
 ```bash
 DISABLE_HTTPS=1
 ENABLE_HTTP_REDIRECT=0
-ENABLE_LETS_ENCRYPT=0
+ENABLE_LETSENCRYPT=0
 ```
 
 ### Do not expose the Jitsi Meet's ports publicly


### PR DESCRIPTION
Fixing typo, could not find ENABLE_LETS_ENCRYPT usage anywhere in jitsi repositories