### PR TITLE
Add JitsiMeet-AutoStart to third-party-software.md

### DIFF
--- a/docs/community/third-party-software.md
+++ b/docs/community/third-party-software.md
@@ -91,6 +91,12 @@ Demo: https://jitsi-admin.de
 Docker:
 https://github.com/H2-invent/jitsi-admin/wiki/Install-jitsi-admin-in-docker
 
+## JitsiMeet-AutoStart
+
+A lightweight, single-page utility for unattended systems that need to automatically join a Jitsi meeting with the camera enabled. Perfect for kiosks, monitoring setups, or any scenario where a system should automatically connect and display video without user interaction. No deployment required.
+
+Github: https://github.com/GammaPi/JitsiMeet-AutoStart
+
 ## Jitsi Config Differ
 
 Web app to compare reference configs between different Jitsi releases. This aims


### PR DESCRIPTION
Adds link to JitsiMeet-AutoStart.

[JitsiMeet-AutoStart](https://github.com/GammaPi/JitsiMeet-AutoStart) is a lightweight, single-page utility for unattended systems that need to automatically join a Jitsi meeting with the camera enabled. Perfect for kiosks, monitoring setups, or any scenario where a system should automatically connect and display video without user interaction.