### PR TITLE
Bind statistics port to localhost only

### DIFF
--- a/docs/devops-guide/faq.md
+++ b/docs/devops-guide/faq.md
@@ -32,6 +32,7 @@ Here is how to remove multiplexing and enable websockets in favor of WebRTC Data
     http-servers {
         public {
             port = 9090
+            host = "localhost"
         }
     }
     websockets {


### PR DESCRIPTION
Added host="localhost" to jvb.conf, because reverse proxy configuration is described to access it - no direct exposure required.