### PR TITLE
docs: mark `hosts` as non-overridable and add migration guidance

### DIFF
--- a/docs/dev-guide/configuration.md
+++ b/docs/dev-guide/configuration.md
@@ -711,7 +711,7 @@ hosts: {
     focus: 'focus.jitsi-meet.example.com',
     muc: 'conference.jitsi-meet.example.com'
 }
-
+```
 ### p2p
 
 type: `Object`


### PR DESCRIPTION
This PR updates the documentation for the `hosts` configuration section.

In Jitsi Meet, the ability to override `hosts` via `configOverwrite` was
removed in commit 97146ed (introduced in version 2.0.10590+). However, the
Handbook documentation still stated that `hosts` could be overridden
dynamically, which caused confusion among developers and integrators.

This PR:
- Marks the `hosts` field as **non-overridable** via `configOverwrite`
- Adds a clear note explaining when and why overriding was removed
- Provides migration guidance using Visitors / JWT roles for setups that used
  hidden or alternate domains
- Cleans up the structure and improves clarity of the section

This resolves the documentation part of jitsi/jitsi-meet#16615.
