### PR TITLE
docs: add setReceiverConstraints and setEffect docs

### DIFF
--- a/docs/dev-guide/ljm-api.md
+++ b/docs/dev-guide/ljm-api.md
@@ -67,6 +67,82 @@ room.join();
 
 After that step you are in the conference. Now you can continue with adding some code that will handle the events and manage the conference.
 
+## API Reference
+
+### setReceiverConstraints
+
+Configures the video quality for remote participant streams.
+
+```javascript
+conference.setReceiverConstraints(videoConstraints);
+```
+
+**Parameters:**
+
+`videoConstraints` - Object containing the following properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `lastN` | number | Maximum number of video streams to receive |
+| `selectedSources` | array | Source names to receive (e.g., `['abc123-v0', 'def456-v0']`) |
+| `onStageSources` | array | Source names for participants on stage |
+| `defaultConstraints` | object | Default quality for all sources `{ maxHeight: 360 }` |
+| `constraints` | object | Per-source quality `{ 'abc123-v0': { maxHeight: 720 } }` |
+
+**Example:**
+
+```javascript
+// Basic usage - receive up to 20 videos at 360p
+conference.setReceiverConstraints({
+    lastN: 20,
+    defaultConstraints: { maxHeight: 360 }
+});
+```
+
+Common `maxHeight` values: `180` (low), `360` (medium), `720` (HD), `1080` (Full HD).
+
+:::warning DEPRECATED
+`setReceiverVideoConstraint(resolution)` is deprecated. Use `setReceiverConstraints()` instead.
+:::
+
+### setEffect
+
+Applies effects to local tracks (e.g., background blur, virtual backgrounds).
+
+```javascript
+track.setEffect(effect);
+```
+
+**Parameters:**
+
+`effect` - Object with the following methods, or `undefined` to remove effect:
+
+| Method | Description |
+|--------|-------------|
+| `isEnabled(track)` | Returns true if effect can be applied to this track |
+| `startEffect(stream)` | Processes stream and returns modified MediaStream |
+| `stopEffect()` | Cleans up effect resources |
+
+**Example:**
+
+```javascript
+const blurEffect = {
+    isEnabled: (track) => track.isVideoTrack(),
+    startEffect: (stream) => {
+        // Apply blur and return processed stream
+        return processedStream;
+    },
+    stopEffect: () => {
+        // Release resources
+    }
+};
+
+localVideoTrack.setEffect(blurEffect);
+
+// Remove effect
+localVideoTrack.setEffect(undefined);
+```
+
 ## Components
 
 See [the full API docs](https://jitsi.github.io/lib-jitsi-meet/).


### PR DESCRIPTION
## Description
Adds missing parameter documentation for `setReceiverConstraints()` and `setEffect()` methods in the lib-jitsi-meet API guide.

## Changes
- Added parameter documentation for `setReceiverConstraints()` with table format
- Documented `setEffect()` interface requirements 
- Added deprecation notice for `setReceiverVideoConstraint()`
- Included practical code examples

## Fixes
Fixes #303

## Context
Issue #303 reported that these method parameters were not documented, making it unclear whether they were objects or strings. This PR provides complete parameter documentation with examples following the handbook's style.