### PR TITLE
Add documentation for `toolbarVisibilityChanged` IFrame API event

### DIFF
--- a/docs/dev-guide/iframe-events.md
+++ b/docs/dev-guide/iframe-events.md
@@ -520,6 +520,18 @@ Provides event visibility notifications for the filmstrip that is being updated:
 }
 ```
 
+### toolbarVisibilityChanged
+
+Provides event notifications when the in-page Jitsi Meet toolbar (toolbox) is shown or hidden.
+
+The listener receives an object with the following structure:
+
+```javascript
+{
+    visible: boolean // Whether the toolbar is currently visible.
+}
+```
+
 ### moderationStatusChanged
 
 Provides event notifications about changes to moderation status.


### PR DESCRIPTION
This PR updates the IFrame API documentation by adding the new `toolbarVisibilityChanged` event. The event notifies when the in-page toolbar visibility changes and exposes:
```
{
    visible: boolean // Whether the toolbar is currently visible.
}
```
This documents the feature that was added in jitsi-meet PR #16659 and requested in issue #16469.

Thanks!
