### PR TITLE
Document toolbarConfig.backgroundColor for IFrame API usage

### DIFF
--- a/docs/dev-guide/configuration.md
+++ b/docs/dev-guide/configuration.md
@@ -126,6 +126,32 @@ customToolbarButtons: [
 ]
 ```
 
+### toolbarConfig
+
+type: `Object`
+
+Options related to toolbar visibility behavior and styling.
+
+Properties:
+
+* `alwaysVisible` - If `true`, the toolbar is always visible. If `false`, it auto-hides after the configured timeouts. Default: `false`.
+* `autoHideWhileChatIsOpen` - If `true`, the toolbar can auto-hide while the chat panel is open. Default: `false`.
+* `backgroundColor` - Optional string. Sets the background color of the main toolbar. Accepts any valid CSS color (for example `'#ff0000'`). This value can also be overridden through `configOverwrite.toolbarConfig.backgroundColor` when using the IFrame API. Default: `'#ffffff'`.
+* `initialTimeout` - Initial number of milliseconds for the toolbar to remain visible when a meeting starts. Default: `20000`.
+* `timeout` - Number of milliseconds for the toolbar to remain visible after user activity. Default: `4000`.
+
+Default:
+
+```javascript
+toolbarConfig: {
+    alwaysVisible: false,
+    autoHideWhileChatIsOpen: false,
+    backgroundColor: '#ffffff',
+    initialTimeout: 20000,
+    timeout: 4000
+}
+```
+
 ### mouseMoveCallbackInterval
 
 type: `Number`

--- a/docs/dev-guide/iframe.md
+++ b/docs/dev-guide/iframe.md
@@ -147,6 +147,22 @@ const options = {
 };
 const api = new JitsiMeetExternalAPI(domain, options);
 ```
+
+You can also override toolbar styling via `configOverwrite`. For example, to change the in-meeting toolbar background color:
+
+```javascript
+const options = {
+    roomName: 'MyRoom',
+    configOverwrite: {
+        toolbarConfig: {
+            backgroundColor: '#ff0000'
+        }
+    }
+};
+
+const api = new JitsiMeetExternalAPI(domain, options);
+```
+
 To pass a JWT token to Jitsi Meet use the following:
 
  ```javascript


### PR DESCRIPTION
This PR updates the handbook to document the toolbar background color configuration that was added in jitsi-meet PR #16585 and requested in issue #16468.

- Adds `toolbarConfig.backgroundColor` to the configuration guide, explaining that it sets the in-meeting toolbar background color and can be used in `config.js` or via `configOverwrite` when embedding.

- Adds an IFrame API example using: `configOverwrite.toolbarConfig.backgroundColor` to customize the toolbar color for embedded deployments.

This complements the feature implemented in jitsi-meet PR #16585 and makes it discoverable for IFrame API users.

Thanks!