### PR TITLE
Document Android system bars behavior after immersive mode removal

### DIFF
--- a/docs/dev-guide/android-sdk.md
+++ b/docs/dev-guide/android-sdk.md
@@ -15,6 +15,15 @@ Android 7.0 (API level 24) or higher is required.
 If you want to see how easy integrating the Jitsi Meet SDK into a native application is, take a look at the
 [sample applications repository](https://github.com/jitsi/jitsi-meet-sdk-samples#android).
 
+### Android system bars behavior (immersive mode removed)
+
+Immersive mode (where the app would hide system status/navigation bars and force a full-screen experience) was removed in PR https://github.com/jitsi/jitsi-meet/pull/16513. The Android SDK no longer forces full-screen hiding of system bars; instead embedded apps should expect status and navigation bars to follow the device's OS defaults.This aligns Jitsi Meet with Android platform expectations and avoids inconsistent UI behavior on different devices.
+
+Integrators embedding the SDK should:
+
+- Design layouts that respect system safe insets and avoid placing important controls under the status or navigation bars.
+- Test behavior across Android versions and devices (system UI and gesture navigation behavior can vary, particularly on Android 14/15+).
+
 ## Build your own, or use a pre-build SDK artifacts/binaries
 
 Jitsi conveniently provides a pre-build SDK artifacts/binaries in its Maven repository. When you do not require any


### PR DESCRIPTION
### Fixes: #602 

### 📝 Summary

This PR updates the Android SDK documentation in the Jitsi Handbook to clarify current system bars behavior after the removal of immersive mode in the Android app.

Recent versions of Jitsi Meet no longer use Android’s immersive full-screen mode, which previously hide the system status/navigation bars. Instead, UI behavior now follows Android OS defaults. This change was introduced in [PR #16513](https://github.com/jitsi/jitsi-meet/pull/16513).

### 📌 What’s included

A new subsection has been added to the Android SDK documentation:

- Explains that immersive mode was removed
- Notes that system bars are now fully controlled by the OS
- Advises SDK embedders to respect safe insets and avoid placing UI under system bars
- Recommends testing layouts across Android versions and device types

### 🎯 Why this is needed

The change in UI behavior affects:
- App layout expectations for developers embedding the SDK
- How the app appears in fullscreen scenarios
- Consistency across Android devices and newer versions (Android 14/15+)

Documenting this behavior reduces confusion and helps integrators design properly around Android system UI constraints.

### 🔗 References

- Removal of immersive mode: https://github.com/jitsi/jitsi-meet/pull/16513
