### PR TITLE
Add authentication configuration for file sharing without tokens

### DIFF
--- a/docs/devops-guide/file-sharing.md
+++ b/docs/devops-guide/file-sharing.md
@@ -124,7 +124,9 @@ pm2 delete jitsi-meet-file-sharing-service
 pm2 start ecosystem.config.js --env production
 ```
 
-- If you are using jwt authentication, make sure you pass 'file-upload' feature in `context.features` in the jwt.
+### Authentication Configuration
+
+- If you are using **JWT authentication**, make sure you pass 'file-upload' feature in `context.features` in the jwt.
 ```
 {
   ...,
@@ -136,12 +138,13 @@ pm2 start ecosystem.config.js --env production
     "features": {
         "file-upload":  true,
         ...
-    }
+    },
     ...
+  }
 }
 ```
-- If you are using some other authentication method, you need to configure jitsi_default_permissions to include it.
-```
+- If you are using **internal authentication** (e.g. `prosodyctl register`) or other authentication methods without tokens, you need to configure `jitsi_default_permissions` in your Prosody config (e.g. `/etc/prosody/conf.avail/your-domain.cfg.lua`) to include `file-upload`.
+```lua
 jitsi_default_permissions = {
         livestreaming = true;
         recording = true;


### PR DESCRIPTION
## Summary
Updates the file sharing documentation to address a common issue where file uploads don't work for authenticated users in non-token setups.

This resolves the issue described in the Jitsi Community Forum post: "There's a problem with the File Sharing feature in Jitsi-Meet" where users couldn't upload files despite having the service configured, due to missing permissions for non-token authentication.

Also solves a syntax error which was pre-existing in the docs.