### PR TITLE
Remove outdated callstats references from documentation (fixes #607)

### DIFF
--- a/docs/dev-guide/configuration.md
+++ b/docs/dev-guide/configuration.md
@@ -443,6 +443,39 @@ Default: `false`
 hideAddRoomButton: false
 ```
 
+## Analytics
+
+### enableDisplayNameInStats
+
+type: `Boolean`
+
+Enables sending participants' display names to analytics services.
+
+```javascript
+enableDisplayNameInStats: false
+```
+
+### enableEmailInStats
+
+type: `Boolean`
+
+Enables sending participants' emails (if available) to analytics services.
+
+```javascript
+enableEmailInStats: false
+```
+
+### feedbackPercentage
+
+type: `Number`
+
+Controls the percentage of automatic feedback shown to participants when analytics is enabled.
+The default value is 100%. If set to 0, no automatic feedback will be requested.
+
+```javascript
+feedbackPercentage: 100
+```
+
 ## Transcriptions
 
 ### autoCaptionOnRecord 

--- a/docs/user-guide/advanced.md
+++ b/docs/user-guide/advanced.md
@@ -35,6 +35,9 @@ These parameters have an effect on the user interface.
 Key                             | Value  | Effect
 ------------------------------- | ------ | -----------------------------------
 `defaultLanguage`               | `en`   | change the UI default language
+`disableThirdPartyRequests`     | `true` | generate avatars locally and disable third-party requests
+`enableDisplayNameInStats`      | `true` | send display names of participants to analytics
+`enableEmailInStats`            | `true` | send email (if available) to analytics
 `enableInsecureRoomNameWarning` | `true` | show a warning label if the room name is deemed insecure
 
 ## Video


### PR DESCRIPTION
This PR removes references to the defunct callstats.io service from the documentation, including the Callstats section in configuration.md and related config options in advanced.md. The feature was previously removed from the codebase, and these docs updates align with that. Fixes #607.