### PR TITLE
ci: cache npm dependencies in handbook CI workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,6 +14,7 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
+        cache: npm
 
     - name: Build
       run: npm ci && npm run build


### PR DESCRIPTION
### Summary

This PR enables npm caching in the CI workflow to reduce dependency installation time.

### Changes
- Enable `cache: 'npm'` in the `actions/setup-node` step.

Previously each run downloaded npm packages from the registry. With caching enabled, npm dependencies can be reused across runs while keeping the build behavior unchanged.