### PR TITLE
ci: migrate handbook CI to official GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,25 +3,41 @@ name: Build GH pages and deploy if on master
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version-file: '.nvmrc'
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
 
-    - name: Build
-      run: npm ci && npm run build
+      - name: Build
+        run: npm ci && npm run build
 
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v2.5.0
-      if: ${{ github.ref == 'refs/heads/master' }}
-      env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./build
+      - name: Upload artifact
+        if: ${{ github.ref == 'refs/heads/master' }}
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./build
+
+  deploy:
+    if: ${{ github.ref == 'refs/heads/master' }}
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Fixes: #626 

### Summary

This PR migrates the handbook CI deployment to the official GitHub Pages workflow.

### Changes
- Replace `peaceiris/actions-gh-pages` with the official GitHub Pages actions:
  - `actions/upload-pages-artifact`
  - `actions/deploy-pages`
- Remove the need for the `ACTIONS_DEPLOY_KEY`
- Use the built-in `GITHUB_TOKEN` for deployment
- Add the required `pages` and `id-token` permissions

This follows GitHub’s recommended Pages deployment model and simplifies the workflow by avoiding SSH deploy key management.

### Note: 
This workflow requires GitHub Pages to be configured with Source -> GitHub Actions in repository settings.