### PR TITLE
docs: fix incorrect onBackPressed return type and remove non-existent onHostStop

### DIFF
--- a/docs/dev-guide/android-sdk.md
+++ b/docs/dev-guide/android-sdk.md
@@ -360,9 +360,6 @@ Should be called from the activity method of the same name.
 #### onBackPressed()
 
 Helper method which should be called from the activity's `onBackPressed` method.
-If this function returns `true`, it means the action was handled and thus no
-extra processing is required; otherwise the app should call the parent's
-`onBackPressed` method.
 
 #### onHostDestroy(...)
 
@@ -372,10 +369,6 @@ Helper method which should be called from the activity's `onDestroy` method.
 
 Helper method which should be called from the activity's `onResume` or `onStop`
 method.
-
-#### onHostStop(...)
-
-Helper method which should be called from the activity's `onSstop` method.
 
 #### onNewIntent(...)
 


### PR DESCRIPTION
## Description
This PR fixes incorrect documentation in the Android SDK dev guide. Specifically, it corrects the return type of `onBackPressed()` in `JitsiMeetActivityDelegate` (which is `void`, not `boolean`) and removes the non-existent `onHostStop()` method.

## Related Issue(s)
Fixes jitsi/jitsi-meet#17208

## Motivation/Rationale
The current documentation is inconsistent with the actual SDK implementation, which can lead to confusion and implementation errors for developers using the Android SDK.

## Types of Changes
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Checklist
- [x] My code follows the project's coding standards.
- [x] I have performed a self-review of my code.
- [x] I have verified that my changes do not break existing functionality.
- [x] I have signed the Contributor License Agreement (CLA).