### PR TITLE
Modify example nginx config to use $request_uri

### DIFF
--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -947,14 +947,14 @@ With nginx, these routes can be forwarded using the following config snippet:
 
 ```nginx
 location /xmpp-websocket {
-    proxy_pass http://localhost:8000/xmpp-websocket;
+    proxy_pass http://localhost:8000$request_uri;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
 }
 
 location /colibri-ws {
-    proxy_pass http://localhost:8000/colibri-ws;
+    proxy_pass http://localhost:8000$request_uri;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";


### PR DESCRIPTION
When deploying the docker jitsi container to use jwt for auth running behind an nginx setup as a reverse proxy, the current example configuration leads to the xmpp not using the token authentication, falling back to anonymous and thus failing.

Changing the redirect to include the actuall request by using $request_uri in the nginx config fixes this issue. 