### PR TITLE
fix: electron build script typo

### DIFF
--- a/docs/dev-guide/electron-sdk.md
+++ b/docs/dev-guide/electron-sdk.md
@@ -200,7 +200,7 @@ When you need to test SDK changes against the Electron app without publishing a 
 git clone https://github.com/jitsi/jitsi-meet-electron-sdk
 cd jitsi-meet-electron-sdk
 npm install
-npm run build
+npm run prebuild
 ```
 
 #### Step 2 — Register the local SDK globally


### PR DESCRIPTION
handbook: https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-electron-sdk

there is no `build` script available in the jitsi-meet-electron-sdk repo. This results into a 'missing script'. 