### PR TITLE
Add MacOS Calendar App section to documentation

### DIFF
--- a/docs/community/third-party-software.md
+++ b/docs/community/third-party-software.md
@@ -130,6 +130,13 @@ Integration of KeyCloak for authentication.
 
 https://github.com/D3473R/jitsi-keycloak
 
+## MacOS Calendar App
+
+A simple app for creating events with video conferencing links for a configurable Jitsi instance.
+
+Mac App Store: https://apps.apple.com/de/app/calendar-freedom/id6759659484?mt=12
+GitHub: https://github.com/mechko/calendar-freedom  
+
 ## Outlook Plugin
 
 Plugin for Adding a "Schedule Jitsi Meeting" Button to Microsoft Outlook.


### PR DESCRIPTION
Added information about a MacOS Calendar app for Jitsi integration.