### PR TITLE
docs(dev-guide): fix grammar, punctuation, and wording issues

### DIFF
--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -4,7 +4,7 @@ title: Contributing Guidelines
 ---
 
 # 🤝 How to Contribute 
-We greatly appreciate your willingness to contribute ❤️ Before you start working however, please take a moment to read and follow this brief guide.
+We greatly appreciate your willingness to contribute ❤️ Before you start working, however, please take a moment to read and follow this brief guide.
 
 # 📥 Reporting Issues and Asking Questions 
 
@@ -12,7 +12,7 @@ We greatly appreciate your willingness to contribute ❤️ Before you start wor
 
 - Feel free to report ***any bugs, ask for new features or anything else*** you need help with. When opening an issue, please provide as much information as possible.
 
-- Please ask any general and implementation specific questions on the [community forum](https://community.jitsi.org/) for support.
+- Please ask any general and implementation-specific questions on the [community forum](https://community.jitsi.org/) for support.
 
 ### 🪲 Bug Reports and Other Issues
 
@@ -49,7 +49,7 @@ If you have an idea for a new feature or something you'd like to see improved in
 
 - Discovered a bug or have a feature request and know how to fix it? Excellent! Keep reading 🔍
 
-- The [Developer Guide](/docs/category/developer-guide) will help you to setup a development environment to start working on the Jitsi Meet applications.
+- The [Developer Guide](/docs/category/developer-guide) will help you to set up a development environment to start working on the Jitsi Meet applications.
 
 ## ✏️ Contributor License Agreement 
 While the Jitsi projects are released under the
@@ -106,7 +106,7 @@ Use your judgement and look into the commit history when in doubt.
 
 ### Comments
 
-* Comments documenting the source code are required.
+* Comments that document the source code are required.
 
   * Comments from which documentation is automatically generated are **not**
     subject to case-by-case decisions. Such comments are used, for example, on

--- a/docs/dev-guide/ljm-api.md
+++ b/docs/dev-guide/ljm-api.md
@@ -3,7 +3,7 @@ id: dev-guide-ljm-api
 title: lib-jitsi-meet API (low level)
 ---
 
-You can use Jitsi Meet API to create Jitsi Meet video conferences with a custom GUI.
+You can use the Jitsi Meet API to create Jitsi Meet video conferences with a custom GUI.
 
 ## Installation
 
@@ -18,7 +18,7 @@ Now you can access Jitsi Meet API through the `JitsiMeetJS` global object.
 
 ## Getting Started
 
-1. The first thing you must do in order to use Jitsi Meet API is to initialize `JitsiMeetJS` object:
+1. The first thing you must do in order to use the Jitsi Meet API is to initialize `JitsiMeetJS` object:
 
 ```javascript
 JitsiMeetJS.init();
@@ -59,7 +59,7 @@ JitsiMeetJS.createLocalTracks().then(onLocalTracks);
 
 NOTE: Adding listeners and creating local streams are not mandatory steps.
 
-6. Then you are ready to create / join a conference :
+6. Then you are ready to create or join a conference:
 
 ```javascript
 room.join();

--- a/docs/dev-guide/web-jitsi-meet.md
+++ b/docs/dev-guide/web-jitsi-meet.md
@@ -4,7 +4,7 @@ title: Developer Guide for Jitsi Meet
 sidebar_label: Jitsi Meet development
 ---
 
-This guide will help you setup a development environment to start working on the Jitsi Meet web app itself.
+This guide will help you set up a development environment to start working on the Jitsi Meet web app itself.
 
 ## Building the sources
 
@@ -57,12 +57,12 @@ The app should be running at https://localhost:8080/
 
 #### Certificate Error
 
-Browsers may show a certificate error since the development certificate is self-signed. It's safe to disregard those
+Browsers may show a certificate error since the development certificate is self-signed. It's safe to disregard that
 warning and continue to your site.
 
 ### Building .debs
 
-To make a deb you can easily deploy to a public test server, ensure you have the lib-jitsi-meet sources you wish, then:
+To create a deb package for deployment to a public test server, ensure you have the desired lib-jitsi-meet sources, then run:
 ```
 npm install
 make

--- a/docs/dev-guide/windows.md
+++ b/docs/dev-guide/windows.md
@@ -39,7 +39,7 @@ sudo apt update && sudo apt upgrade -y
 
 ### Install nvm
 
-[nvm](https://github.com/nvm-sh/nvm) (Node Version Manager) lets you install and switch between multiple versions of Node.js. The Jitsi Meet repository includes an `.nvmrc` file that specifies the exact Node.js version the project requires. When you run `nvm install` or `nvm use` inside the project directory, nvm reads this file and automatically installs or switches to the correct version. This means you do not need to look up which version to install and the setup stays correct even when the project updates its Node.js requirement.
+[nvm](https://github.com/nvm-sh/nvm) (Node Version Manager) lets you install and switch between multiple versions of Node.js. The Jitsi Meet repository includes an `.nvmrc` file that specifies the exact Node.js version the project requires. When you run `nvm install` or `nvm use` inside the project directory, nvm reads this file and automatically installs or switches to the correct version. This means you do not need to look up which version to install, and the setup stays correct even when the project updates its Node.js requirement.
 
 Install nvm by running:
 


### PR DESCRIPTION
## Summary 
This PR fixes several minor grammar, punctuation, and wording issues across the developer guide documentation. 

## Changes Made
- Corrected `setup` → `set up` where used as a verb
-  Fixed missing articles such as `the Jitsi Meet API` 
- Improved sentence readability in a few sections 
- Fixed minor punctuation and grammar inconsistencies

 ## Impact 
These changes improve documentation clarity and readability for contributors and developers without changing the technical meaning or functionality.