### PR TITLE
docs: Document the setMeetingTimer iframe API command

### DIFF
--- a/docs/dev-guide/iframe-commands.md
+++ b/docs/dev-guide/iframe-commands.md
@@ -755,3 +755,24 @@ api.executeCommand('setVirtualBackground',
     backgroundImage: string // Required. Base64 image string, eg. "data:image/png;base64, iVBOR...".
 );
 ```
+
+### setMeetingTimer
+
+Drives the meeting-pace timer shown in the conference info bar. Use this to
+set the meeting's scheduled duration (and, optionally, how much of it has
+already elapsed). This is the way to control the timer in deployments that do
+not use calendar sync.
+
+A positive `duration` starts or updates the timer; omitting `duration` (or
+passing a value `<= 0`) clears it.
+
+```javascript
+api.executeCommand('setMeetingTimer', {
+    duration: number, // The scheduled meeting duration, in seconds. Omit or pass <= 0 to hide the timer.
+    elapsed: number // Optional. Seconds already elapsed since the scheduled start. May exceed `duration` for a participant joining after the scheduled end. Defaults to 0.
+});
+```
+
+The timer is enabled by default and renders nothing until a duration is known
+(from this command or from calendar sync). To hide it entirely — even when a
+duration is available — set `configOverwrite.timeTimer = { enabled: false }`.


### PR DESCRIPTION
Documents the `setMeetingTimer` iframe API command on the iframe commands reference page.

The command drives the meeting-pace timer shown in the conference info bar — it sets the scheduled meeting duration (and optionally how much has already elapsed). This is how deployments that do not use calendar sync control the timer.

Companion to the feature PR: jitsi/jitsi-meet#17468

🤖 Generated with [Claude Code](https://claude.com/claude-code)