### PR TITLE
docs(devops-guide-docker): document display name and private chat options

### DIFF
--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -329,6 +329,9 @@ Variable | Description | Example
 `DISABLE_AUDIO_LEVELS` | Disable measuring of audio levels | 0
 `ENABLE_NOISY_MIC_DETECTION` | Enable noisy mic detection | 1
 `ENABLE_BREAKOUT_ROOMS` | Enable breakout rooms | 1
+`ENABLE_REQUIRE_DISPLAY_NAME` | Force all participants to set a display name | 0
+`DISABLE_PRIVATE_CHAT` | Disable private messaging between users | 0
+
 ### Jigasi SIP gateway (audio only) configuration
 
 If you want to enable the SIP gateway, these options are required:


### PR DESCRIPTION
Document two Docker environment variables in the Features configuration (`config.js`) section of the self-hosting guide:
- `ENABLE_REQUIRE_DISPLAY_NAME` — forces all participants to set a display name before joining
- `DISABLE_PRIVATE_CHAT` — disables private messaging between users
