### PR TITLE
docs(configuration): document prejoinConfig (incl. hideExtraJoinButtons)

### DIFF
--- a/docs/dev-guide/configuration.md
+++ b/docs/dev-guide/configuration.md
@@ -1152,6 +1152,35 @@ participantsPane: {
 }
 ```
 
+## Prejoin
+
+### prejoinConfig
+
+type: `Object`
+
+Options related to the prejoin (pre-meeting) screen, shown before a participant joins the conference so they can configure their devices.
+
+Default: **unset**
+
+Properties:
+* `enabled` - When `true`, shows the prejoin screen before joining, where the user can configure their devices. Default: `true`.
+* `hideDisplayName` - Hides the participant name editing field on the prejoin screen. If `requireDisplayName` is also `true`, a name must still be provided through the JWT or the `userInfo` from the iframe API init object for this to have an effect. Default: `false`.
+* `hideExtraJoinButtons` - List of secondary join buttons to hide from the extra join options dropdown on the prejoin screen. Supported values: `'no-audio'` (the "Join without audio" button, which joins the conference without acquiring a microphone) and `'by-phone'` (the "Join by phone" button, which lets the participant dial in for audio while video stays in the browser; requires dial-in to be configured). Default: `[]` (all buttons shown).
+* `preCallTestEnabled` - Enables the pre-call connection/quality test on the prejoin page. ICE server credentials must be provided via `preCallTestICEUrl`. Default: `false`.
+* `preCallTestICEUrl` - URL that provides the ICE server credentials used by the pre-call test. Default: `''`.
+* `showHangUp` - Shows the hang up button on the prejoin/lobby screen. Default: `true`.
+
+```javascript
+prejoinConfig: {
+    enabled: true,
+    hideDisplayName: false,
+    hideExtraJoinButtons: ['no-audio', 'by-phone'],
+    preCallTestEnabled: false,
+    preCallTestICEUrl: '',
+    showHangUp: true
+}
+```
+
 ## Recording
 
 ### dropbox


### PR DESCRIPTION
## What

Adds a `## Prejoin` section documenting the `prejoinConfig` object on the Configuration page, which was previously undocumented.

Documents all properties, sourced from the reference `config.js`:
- `enabled`
- `hideDisplayName`
- `hideExtraJoinButtons` — including the two supported values, `'no-audio'` (Join without audio) and `'by-phone'` (Join by phone / dial-in)
- `preCallTestEnabled`, `preCallTestICEUrl`
- `showHangUp`

## Why

`prejoinConfig` (and in particular `hideExtraJoinButtons`, which controls the "Join without audio" and "Join by phone" fallback buttons) had no coverage in the handbook. Follows the existing object-config formatting used elsewhere on the page.
