### PR TITLE
fix(docker): update the Prosody data path to /var/lib/prosody/data

### DIFF
--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -558,15 +558,15 @@ Variable | Description | Example
 ### Jitsi Meet configuration
 
 Jitsi-Meet uses two configuration files for changing default settings within
-the web interface: ``config.js`` and ``interface_config.js``. The files are
-located within the ``CONFIG/web/`` directory configured within your environment file.
+the web interface: ``config.js`` and ``interface_config.js``.
 
-These files are re-created on every container restart.
-If you'd like to provide your own settings, create your own config files:
+Both files are generated inside the container on every start and are not written to the host,
+so editing them directly is not possible. If you'd like to provide your own settings, create your
+own config files in the ``CONFIG/web/`` directory configured within your environment file:
 ``custom-config.js`` and ``custom-interface_config.js``.
 
 It's enough to provide your relevant settings only, the docker scripts will
-append your custom files to the default ones!
+append your custom files to the generated ones!
 
 ### Authentication
 

--- a/docs/devops-guide/docker.md
+++ b/docs/devops-guide/docker.md
@@ -168,7 +168,7 @@ The following paths moved:
 
 What | Old location | New location | Migration
 --- | --- | --- | ---
-Prosody data | `${CONFIG}/prosody/config/data` | `${CONFIG}/storage/prosody` | Automatic on the first start
+Prosody data | `${CONFIG}/prosody/config/data` | `${CONFIG}/storage/prosody/data` | Automatic on the first start
 Web TLS material | `${CONFIG}/web` | `${CONFIG}/storage/web` | Automatic on the first start
 Jibri recordings and logs | `${CONFIG}/jibri/recordings`, `${CONFIG}/jibri/logs` | `${CONFIG}/storage/jibri` | Move the existing files yourself if you want to keep them
 Transcripts | `${CONFIG}/transcripts` | `${CONFIG}/storage/transcripts` | Move the existing files yourself if you want to keep them
@@ -618,7 +618,7 @@ prosodyctl --config /run/prosody/config/prosody.cfg.lua unregister TheDesiredUse
 To list all users, run the following command in the container:
 
 ```bash
-find /var/lib/prosody/meet%2ejitsi/accounts -type f -exec basename {} .dat \;
+find /var/lib/prosody/data/meet%2ejitsi/accounts -type f -exec basename {} .dat \;
 ```
 
 #### Authentication using LDAP


### PR DESCRIPTION
After [PR #2304](https://github.com/jitsi/docker-jitsi-meet/pull/2304), Prosody's data folder is changed. This PR updates the handbook according to this change.