### PR TITLE
docs(dev-guide): document the second-screen API

### DIFF
--- a/docs/dev-guide/configuration.md
+++ b/docs/dev-guide/configuration.md
@@ -1367,8 +1367,9 @@ The feature requires the [Window Management API][window-management], so it is
 Chromium-only. It is aimed at managed or kiosk room appliances, which also need
 the `window-management` browser permission granted by policy, and the
 `automatic-fullscreen` permission if the second window is to go fullscreen on its
-own. On a browser without the API the feature stays off and the command reports a
-`second-screen-error` rather than doing nothing silently.
+own. On a browser without the API the feature stays off and the command reports
+[`secondScreenError`](dev-guide-iframe-events#secondscreenerror) with
+`second-screen-disabled` rather than doing nothing silently.
 
 Default: **unset** (disabled)
 

--- a/docs/dev-guide/configuration.md
+++ b/docs/dev-guide/configuration.md
@@ -1353,6 +1353,36 @@ screenshotCapture: {
 }
 ```
 
+## Second screen
+### secondScreen
+
+type: `Object`
+
+Options related to rendering meeting surfaces on additional physical displays.
+When enabled, an embedder can drive one or more extra windows through the
+[`setSecondScreen`](dev-guide-iframe-commands#setsecondscreen) command, and
+participants get in-app controls to send a tile to another display.
+
+The feature requires the [Window Management API][window-management], so it is
+Chromium-only. It is aimed at managed or kiosk room appliances, which also need
+the `window-management` browser permission granted by policy, and the
+`automatic-fullscreen` permission if the second window is to go fullscreen on its
+own. On a browser without the API the feature stays off and the command reports a
+`second-screen-error` rather than doing nothing silently.
+
+Default: **unset** (disabled)
+
+Properties:
+* `enabled` - Whether the feature is enabled or not.
+
+```javascript
+secondScreen: {
+    enabled: true
+}
+```
+
+[window-management]: https://developer.mozilla.org/en-US/docs/Web/API/Window_Management_API
+
 ## Security UI
 ### securityUi
 

--- a/docs/dev-guide/configuration.md
+++ b/docs/dev-guide/configuration.md
@@ -1363,12 +1363,13 @@ When enabled, an embedder can drive one or more extra windows through the
 [`setSecondScreen`](dev-guide-iframe-commands#setsecondscreen) command, and
 participants get in-app controls to send a tile to another display.
 
-The feature requires the [Window Management API][window-management], so it is
-Chromium-only. It is aimed at managed or kiosk room appliances, which also need
-the `window-management` browser permission granted by policy, and the
-`automatic-fullscreen` permission if the second window is to go fullscreen on its
-own. On a browser without the API the feature stays off and the command reports
-[`secondScreenError`](dev-guide-iframe-events#secondscreenerror) with
+The feature requires the
+[Window Management API](https://developer.mozilla.org/en-US/docs/Web/API/Window_Management_API),
+so it is Chromium-only. It is aimed at managed or kiosk room appliances, which
+also need the `window-management` browser permission granted by policy, and the
+`automatic-fullscreen` permission if the second window is to go fullscreen on
+its own. On a browser without the API the feature stays off and the command
+reports [`secondScreenError`](dev-guide-iframe-events#secondscreenerror) with
 `second-screen-disabled` rather than doing nothing silently.
 
 Default: **unset** (disabled)
@@ -1381,8 +1382,6 @@ secondScreen: {
     enabled: true
 }
 ```
-
-[window-management]: https://developer.mozilla.org/en-US/docs/Web/API/Window_Management_API
 
 ## Security UI
 ### securityUi

--- a/docs/dev-guide/iframe-commands.md
+++ b/docs/dev-guide/iframe-commands.md
@@ -793,3 +793,95 @@ api.executeCommand('setParticipantProperties', {
     session_id: 'abc123'
 });
 ```
+
+### setSecondScreen
+
+Renders a meeting surface in its own window on another physical display: the
+active-speaker stage, a screenshare, a tile grid of everyone, the whiteboard, or
+the video being shared in the meeting. The window is a view onto the existing
+conference, so it does not join the meeting a second time, duplicate media
+subscriptions, or play the audio twice.
+
+Requires `secondScreen: { enabled: true }` in [config.js] and the
+[Window Management API][window-management] (Chromium only). See the
+[`secondScreen`](dev-guide-configuration#secondscreen) configuration option for
+the browser permissions a deployment needs.
+
+```javascript
+api.executeCommand('setSecondScreen', {
+    id: string, // Optional. Identifies the window, so several can be driven at once. Defaults to 'default'.
+    source: Object, // What to render. Omit it to close this window.
+    screen: number // Optional. Index into the displays reported by the Window Management API.
+});
+```
+
+The `source` object selects content by name rather than by stream, because an
+embedder has no access to the meeting's media tracks:
+
+```javascript
+{
+    role: string, // Optional. One of 'stage', 'screenshare', 'tile', 'whiteboard', 'sharedvideo'.
+    participant: string, // Optional. Id of a participant to render. On its own it pins that participant.
+    media: string // Optional. 'camera' or 'desktop', for an explicitly pinned participant. Defaults to 'camera'.
+}
+```
+
+The roles stay live: `stage` follows the active speaker and `tile` follows
+conference membership, so neither needs to be re-sent as the meeting changes.
+
+| `source` | Result |
+| --- | --- |
+| `{ role: 'stage' }` | The active-speaker stage |
+| `{ role: 'tile' }` | A tile grid of every participant |
+| `{ role: 'screenshare' }` | Whatever is being shared, full-bleed |
+| `{ role: 'screenshare', participant: 'abc123' }` | That participant's screenshare, when several are live at once |
+| `{ role: 'whiteboard' }` | The collaborative whiteboard |
+| `{ role: 'sharedvideo' }` | The video shared in the meeting, muted and view-only |
+| `{ participant: 'abc123' }` | That participant, featured, with a filmstrip |
+| `{ participant: 'abc123', media: 'desktop' }` | That participant's screen rather than their camera |
+
+Send the same `id` again to change what a window shows; the window is updated in
+place rather than reopened. Send the command with no `source` to close it:
+
+```javascript
+// Put the active speaker on the first external display.
+api.executeCommand('setSecondScreen', {
+    id: 'stage-screen',
+    source: { role: 'stage' }
+});
+
+// Same window, now showing the whiteboard.
+api.executeCommand('setSecondScreen', {
+    id: 'stage-screen',
+    source: { role: 'whiteboard' }
+});
+
+// Close it.
+api.executeCommand('setSecondScreen', { id: 'stage-screen' });
+```
+
+A room appliance driving two displays picks the screen explicitly:
+
+```javascript
+api.executeCommand('setSecondScreen', {
+    id: 'tv-left',
+    source: { role: 'stage' },
+    screen: 1
+});
+api.executeCommand('setSecondScreen', {
+    id: 'tv-right',
+    source: { role: 'tile' },
+    screen: 2
+});
+```
+
+Opening a window is subject to the browser's popup blocker, and placing it on a
+chosen display needs the window-management permission, so the command is not
+guaranteed to succeed. Listen for
+[`secondScreenError`](dev-guide-iframe-events#secondscreenerror) to find out why
+it did not, and for
+[`secondScreenClosed`](dev-guide-iframe-events#secondscreenclosed) to know when a
+window has gone, including when a user closes it by hand on the other display.
+
+[config.js]: https://github.com/jitsi/jitsi-meet/blob/master/config.js
+[window-management]: https://developer.mozilla.org/en-US/docs/Web/API/Window_Management_API

--- a/docs/dev-guide/iframe-commands.md
+++ b/docs/dev-guide/iframe-commands.md
@@ -797,10 +797,10 @@ api.executeCommand('setParticipantProperties', {
 ### setSecondScreen
 
 Renders a meeting surface in its own window on another physical display: the
-active-speaker stage, a screenshare, a tile grid of everyone, the whiteboard, or
-the video being shared in the meeting. The window is a view onto the existing
-conference, so it does not join the meeting a second time, duplicate media
-subscriptions, or play the audio twice.
+main stage, a screenshare, a tile grid of everyone, the whiteboard, or the video
+being shared in the meeting. The window is a view onto the existing conference,
+so it does not join the meeting a second time, duplicate media subscriptions, or
+play the audio twice.
 
 Requires `secondScreen: { enabled: true }` in [config.js] and the
 [Window Management API][window-management] (Chromium only). See the
@@ -826,12 +826,15 @@ embedder has no access to the meeting's media tracks:
 }
 ```
 
-The roles stay live: `stage` follows the active speaker and `tile` follows
+The roles stay live: `stage` follows the meeting's main stage and `tile` follows
 conference membership, so neither needs to be re-sent as the meeting changes.
+`stage` shows whoever the meeting itself is showing large, which is the active
+speaker until somebody pins a participant and the pinned one after that, so a
+display driven this way follows a pin rather than ignoring it.
 
 | `source` | Result |
 | --- | --- |
-| `{ role: 'stage' }` | The active-speaker stage |
+| `{ role: 'stage' }` | The main stage: the active speaker, or the pinned participant when there is one |
 | `{ role: 'tile' }` | A tile grid of every participant |
 | `{ role: 'screenshare' }` | Whatever is being shared, full-bleed |
 | `{ role: 'screenshare', participant: 'abc123' }` | That participant's screenshare, when several are live at once |
@@ -844,7 +847,7 @@ Send the same `id` again to change what a window shows; the window is updated in
 place rather than reopened. Send the command with no `source` to close it:
 
 ```javascript
-// Put the active speaker on the first external display.
+// Put the main stage on the first external display.
 api.executeCommand('setSecondScreen', {
     id: 'stage-screen',
     source: { role: 'stage' }

--- a/docs/dev-guide/iframe-events.md
+++ b/docs/dev-guide/iframe-events.md
@@ -930,7 +930,8 @@ Provides event notifications about what a second-screen window is currently
 rendering. Fired when a window is first given a source, whenever that source is
 changed with [`setSecondScreen`](dev-guide-iframe-commands#setsecondscreen), and
 whenever a live role resolves to a different participant, so a `stage` window
-emits this every time the active speaker changes.
+emits this every time the meeting's main stage changes, whether that is a new
+active speaker or a participant somebody pinned.
 
 The listener receives an object with the following structure:
 
@@ -942,8 +943,11 @@ The listener receives an object with the following structure:
 }
 ```
 
-`participantId` is `null` for a source that is not backed by a participant, such
-as the whiteboard, and for one whose participant has no video to render yet.
+`participantId` is `null` when nothing in the meeting backs the source: the
+`whiteboard`, `sharedvideo` and `tile` roles, a `screenshare` role while nobody
+is sharing, or a named participant who has since left. A participant who is
+there but has no video to render still reports their id, because the source
+resolves the participant independently of the track.
 
 ### secondScreenClosed
 
@@ -961,9 +965,11 @@ The listener receives an object with the following structure:
 
 ### secondScreenError
 
-Provides event notifications about a second-screen window that could not be
-opened or set up. No window exists afterwards, so nothing has to be closed in
-response, and retrying the command is safe.
+Provides event notifications about a second-screen window that failed. Nearly
+all of these are failures to open or set up the window: no window exists
+afterwards, so nothing has to be closed in response, and retrying the command is
+safe. The exception is `shared-video-error`, which comes from a window that is
+already open and stays open.
 
 The listener receives an object with the following structure:
 
@@ -983,6 +989,13 @@ The listener receives an object with the following structure:
 | `window-management-unavailable` | The window-management permission was denied or is unavailable, so the window cannot be placed on a chosen display. |
 | `window-load-failed` | The window opened but never loaded the expected page, or was served something else, for example by a proxy or a redirect. |
 | `window-setup-failed` | The window loaded but could not be prepared for rendering. |
+| `shared-video-error` | A `sharedvideo` window could not play the video being shared in the meeting. |
+
+`shared-video-error` is the only code that does not mean the window is gone. The
+window stays open, keeps its id, and renders a message in place of the player,
+so an embedder that does not want it left there has to close it with
+`setSecondScreen` and no `source`. Sharing a different video gives that window a
+fresh attempt.
 
 [config.js]: https://github.com/jitsi/jitsi-meet/blob/master/config.js
 [interface_config.js]: https://github.com/jitsi/jitsi-meet/blob/master/interface_config.js

--- a/docs/dev-guide/iframe-events.md
+++ b/docs/dev-guide/iframe-events.md
@@ -924,6 +924,66 @@ The listener receives an object with the following structure:
 }
 ```
 
+### secondScreenSourceChanged
+
+Provides event notifications about what a second-screen window is currently
+rendering. Fired when a window is first given a source, whenever that source is
+changed with [`setSecondScreen`](dev-guide-iframe-commands#setsecondscreen), and
+whenever a live role resolves to a different participant, so a `stage` window
+emits this every time the active speaker changes.
+
+The listener receives an object with the following structure:
+
+```javascript
+{
+    id: string, // the window id
+    source: Object, // the source descriptor the window was given
+    participantId: string|null // the participant currently backing it, if any
+}
+```
+
+`participantId` is `null` for a source that is not backed by a participant, such
+as the whiteboard, and for one whose participant has no video to render yet.
+
+### secondScreenClosed
+
+Provides event notifications about a second-screen window that has gone away.
+Fired whether it was closed through the API, closed by a user from the meeting,
+closed by hand on the other display, or torn down because the conference ended.
+
+The listener receives an object with the following structure:
+
+```javascript
+{
+    id: string // the window id
+}
+```
+
+### secondScreenError
+
+Provides event notifications about a second-screen window that could not be
+opened or set up. No window exists afterwards, so nothing has to be closed in
+response, and retrying the command is safe.
+
+The listener receives an object with the following structure:
+
+```javascript
+{
+    id: string, // the window id
+    error: string // why it failed
+}
+```
+
+`error` is one of:
+
+| Value | Meaning |
+| --- | --- |
+| `second-screen-disabled` | The feature is off: either `secondScreen.enabled` is not set, or the browser has no Window Management API. |
+| `popup-blocked` | The browser refused to open the window. It was not opened from a user gesture, or popups are blocked for the site. |
+| `window-management-unavailable` | The window-management permission was denied or is unavailable, so the window cannot be placed on a chosen display. |
+| `window-load-failed` | The window opened but never loaded the expected page, or was served something else, for example by a proxy or a redirect. |
+| `window-setup-failed` | The window loaded but could not be prepared for rendering. |
+
 [config.js]: https://github.com/jitsi/jitsi-meet/blob/master/config.js
 [interface_config.js]: https://github.com/jitsi/jitsi-meet/blob/master/interface_config.js
 [EventEmitter]: https://nodejs.org/api/events.html


### PR DESCRIPTION
**The multi-screen feature landed in jitsi-meet across several PRs without any handbook coverage, so embedders currently have no way to discover that it exists, what it accepts, or what a deployment needs before it will work at all. This adds the missing pages.**

**`iframe-commands.md`** gains `setSecondScreen`: the window id, the source descriptor and every role it accepts, explicit screen selection, updating a window in place versus closing it, and a worked example for a room appliance driving two displays. It leads with what the command is not, since that is the first thing an embedder asks: the window is a view onto the existing conference, so it does not join the meeting twice, duplicate media subscriptions, or play the audio again. A table maps each `source` form to what it renders, and the live roles are called out as live, so `stage` and `tile` are not needlessly re-sent as the meeting changes. It also says plainly that the command can fail, since opening a window is subject to the popup blocker and placing it needs the window-management permission, and points at the events rather than letting embedders assume success.

**`iframe-events.md`** gains `secondScreenSourceChanged`, `secondScreenClosed` and `secondScreenError`, with their payloads and, in particular, when each fires, which is not guessable from the names: a `stage` window emits `secondScreenSourceChanged` on every active-speaker change, `secondScreenClosed` fires however the window went, including a user closing it by hand on the other display, and after `secondScreenError` no window exists, so nothing needs closing and retrying is safe. All six error codes get a table with the actual cause of each, including the one that leaves its window open.

**`configuration.md`** gains a `secondScreen` section covering the config option, the Window Management API requirement that makes it Chromium-only, and the `window-management` and `automatic-fullscreen` browser permissions a kiosk or room appliance has to be granted by policy. Without that last part the feature can be enabled in config and still not work, with nothing explaining why.

Everything is written against the implementation rather than from the PR descriptions: the command name and argument shape from `modules/API/API.js`, the event names and payloads from `modules/API/external/external_api.js`, and the error codes and the conditions producing them from `react/features/multi-screen/functions.web.ts` on master.

No existing text is changed; every hunk is an addition. The new cross-links use the `dev-guide-*` doc ids in both directions, so the command, the events and the config option each reach the other two, and I added the `[config.js]` link definition that `iframe-commands.md` was missing, since the new text references it.